### PR TITLE
Make Integer deserializing be more forgiving

### DIFF
--- a/src/main/java/de/sstoehr/harreader/jackson/DefaultMapperFactory.java
+++ b/src/main/java/de/sstoehr/harreader/jackson/DefaultMapperFactory.java
@@ -13,6 +13,7 @@ public class DefaultMapperFactory implements MapperFactory {
         SimpleModule module = new SimpleModule();
         if (mode == HarReaderMode.LAX) {
             module.addDeserializer(Date.class, new ExceptionIgnoringDateDeserializer());
+            module.addDeserializer(Integer.class, new ExceptionIgnoringIntegerDeserializer());
         }
         mapper.registerModule(module);
         return mapper;

--- a/src/main/java/de/sstoehr/harreader/jackson/ExceptionIgnoringIntegerDeserializer.java
+++ b/src/main/java/de/sstoehr/harreader/jackson/ExceptionIgnoringIntegerDeserializer.java
@@ -1,0 +1,21 @@
+package de.sstoehr.harreader.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.std.NumberDeserializers;
+
+import java.io.IOException;
+
+public class ExceptionIgnoringIntegerDeserializer extends JsonDeserializer<Integer> {
+    @Override
+    public Integer deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        try {
+            NumberDeserializers.IntegerDeserializer integerDeserializer = new NumberDeserializers.IntegerDeserializer(Integer.class, null);
+            return integerDeserializer.deserialize(jp, ctxt);
+        } catch (IOException e) {
+            //ignore
+        }
+        return null;
+    }
+}

--- a/src/test/java/de/sstoehr/harreader/HarReaderTest.java
+++ b/src/test/java/de/sstoehr/harreader/HarReaderTest.java
@@ -36,6 +36,19 @@ public class HarReaderTest {
         Assert.assertNotNull(har);
     }
 
+    @Test(expected = HarReaderException.class)
+    public void invalidIntegerStrict() throws HarReaderException {
+        File harFile = new File("src/test/resources/sstoehr.invalid-integer.har");
+        harReader.readFromFile(harFile);
+    }
+
+    @Test
+    public void invalidIntegerLax() throws HarReaderException {
+        File harFile = new File("src/test/resources/sstoehr.invalid-integer.har");
+        Har har = harReader.readFromFile(harFile, HarReaderMode.LAX);
+        Assert.assertNotNull(har);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void mapperFactoryNotNull() {
         new HarReader(null);

--- a/src/test/resources/sstoehr.invalid-integer.har
+++ b/src/test/resources/sstoehr.invalid-integer.har
@@ -1,0 +1,962 @@
+{
+  "log": {
+    "version": "1.1",
+    "creator": {
+      "name": "Firebug",
+      "version": "1.12"
+    },
+    "browser": {
+      "name": "Firefox",
+      "version": "26.0"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2014-01-26T18:37:43.813+01:00",
+        "id": "page_3",
+        "title": "Home — Sebastian Stöhr",
+        "pageTimings": {
+          "onContentLoad": 3910,
+          "onLoad": -1
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2014-01-26T18:37:43.813+01:00",
+        "time": 3804,
+        "request": {
+          "method": "GET",
+          "url": "http://www.sebastianstoehr.de/assets/app-176c7b354c124a4593b8d4ac674d69e6.css",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "www.sebastianstoehr.de"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,*/*;q=0.1"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "de-de,de;q=0.8,en-us;q=0.5,en;q=0.3"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.sebastianstoehr.de/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 676,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sun, 26 Jan 2014 17:37:44 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Fri, 10 Jan 2014 17:10:50 GMT"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "3412"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=15552000"
+            },
+            {
+              "name": "Expires",
+              "value": "Fri, 25 Jul 2014 17:37:44 GMT"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Keep-Alive",
+              "value": "timeout=2, max=200"
+            },
+            {
+              "name": "Connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            }
+          ],
+          "content": {
+            "mimeType": "text/css",
+            "size": 12647,
+            "text": "--- REMOVED ---\n"
+          },
+          "redirectURL": "",
+          "headersSize": 362,
+          "bodySize": 3412
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 5,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 3778,
+          "receive": 63596250212317
+        },
+        "serverIPAddress": "2001:8d8:1000:30ff:1bb6:8823:a9a3:a003",
+        "connection": "80"
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2014-01-26T18:37:43.813+01:00",
+        "time": 9092,
+        "request": {
+          "method": "GET",
+          "url": "http://www.sebastianstoehr.de/res/images/portfolio/woeste-alumni/header-600x131-bf1788.jpg",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "www.sebastianstoehr.de"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0"
+            },
+            {
+              "name": "Accept",
+              "value": "image/png,image/*;q=0.8,*/*;q=0.5"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "de-de,de;q=0.8,en-us;q=0.5,en;q=0.3"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.sebastianstoehr.de/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 704,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sun, 26 Jan 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Sat, 11 Jan 2014 10:56:50 GMT"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "16997"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=15552000"
+            },
+            {
+              "name": "Expires",
+              "value": "Fri, 25 Jul 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Keep-Alive",
+              "value": "timeout=2, max=200"
+            },
+            {
+              "name": "Connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "image/jpeg"
+            }
+          ],
+          "content": {
+            "mimeType": "image/jpeg",
+            "size": 132,
+            "text": "Die Quelle von diesem URL ist kein Text:: http://www.sebastianstoehr.de/res/images/portfolio/woeste-alumni/header-600x131-bf1788.jpg"
+          },
+          "redirectURL": "",
+          "headersSize": 318,
+          "bodySize": 16997
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 3804,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 5209,
+          "receive": 79
+        },
+        "serverIPAddress": "2001:8d8:1000:30ff:1bb6:8823:a9a3:a003",
+        "connection": "80"
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2014-01-26T18:37:43.813+01:00",
+        "time": 9139,
+        "request": {
+          "method": "GET",
+          "url": "http://www.sebastianstoehr.de/res/images/portfolio/sebastian-stoehr/header-600x131-415442.jpg",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "www.sebastianstoehr.de"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0"
+            },
+            {
+              "name": "Accept",
+              "value": "image/png,image/*;q=0.8,*/*;q=0.5"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "de-de,de;q=0.8,en-us;q=0.5,en;q=0.3"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.sebastianstoehr.de/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 707,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sun, 26 Jan 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Sat, 11 Jan 2014 10:56:50 GMT"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "28351"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=15552000"
+            },
+            {
+              "name": "Expires",
+              "value": "Fri, 25 Jul 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Keep-Alive",
+              "value": "timeout=2, max=200"
+            },
+            {
+              "name": "Connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "image/jpeg"
+            }
+          ],
+          "content": {
+            "mimeType": "image/jpeg",
+            "size": 135,
+            "text": "Die Quelle von diesem URL ist kein Text:: http://www.sebastianstoehr.de/res/images/portfolio/sebastian-stoehr/header-600x131-415442.jpg"
+          },
+          "redirectURL": "",
+          "headersSize": 318,
+          "bodySize": 28351
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 3804,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 5240,
+          "receive": 95
+        },
+        "serverIPAddress": "2001:8d8:1000:30ff:1bb6:8823:a9a3:a003",
+        "connection": "80"
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2014-01-26T18:37:43.813+01:00",
+        "time": 9164,
+        "request": {
+          "method": "GET",
+          "url": "http://www.sebastianstoehr.de/res/images/portfolio/abizeitung/header-600x131-603283.jpg",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "www.sebastianstoehr.de"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0"
+            },
+            {
+              "name": "Accept",
+              "value": "image/png,image/*;q=0.8,*/*;q=0.5"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "de-de,de;q=0.8,en-us;q=0.5,en;q=0.3"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.sebastianstoehr.de/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 701,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sun, 26 Jan 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Sat, 11 Jan 2014 10:56:50 GMT"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "73064"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=15552000"
+            },
+            {
+              "name": "Expires",
+              "value": "Fri, 25 Jul 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Keep-Alive",
+              "value": "timeout=2, max=200"
+            },
+            {
+              "name": "Connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "image/jpeg"
+            }
+          ],
+          "content": {
+            "mimeType": "image/jpeg",
+            "size": 129,
+            "text": "Die Quelle von diesem URL ist kein Text:: http://www.sebastianstoehr.de/res/images/portfolio/abizeitung/header-600x131-603283.jpg"
+          },
+          "redirectURL": "",
+          "headersSize": 318,
+          "bodySize": 73064
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 3804,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 5217,
+          "receive": 143
+        },
+        "serverIPAddress": "2001:8d8:1000:30ff:1bb6:8823:a9a3:a003",
+        "connection": "80"
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2014-01-26T18:37:43.814+01:00",
+        "time": 9156,
+        "request": {
+          "method": "GET",
+          "url": "http://www.sebastianstoehr.de/res/images/portfolio/junge-liberale/header-600x131-a069fc.jpg",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "www.sebastianstoehr.de"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0"
+            },
+            {
+              "name": "Accept",
+              "value": "image/png,image/*;q=0.8,*/*;q=0.5"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "de-de,de;q=0.8,en-us;q=0.5,en;q=0.3"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.sebastianstoehr.de/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 705,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sun, 26 Jan 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Sat, 11 Jan 2014 10:56:50 GMT"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "49555"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=15552000"
+            },
+            {
+              "name": "Expires",
+              "value": "Fri, 25 Jul 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Keep-Alive",
+              "value": "timeout=2, max=200"
+            },
+            {
+              "name": "Connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "image/jpeg"
+            }
+          ],
+          "content": {
+            "mimeType": "image/jpeg",
+            "size": 133,
+            "text": "Die Quelle von diesem URL ist kein Text:: http://www.sebastianstoehr.de/res/images/portfolio/junge-liberale/header-600x131-a069fc.jpg"
+          },
+          "redirectURL": "",
+          "headersSize": 318,
+          "bodySize": 49555
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 3803,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 5222,
+          "receive": 131
+        },
+        "serverIPAddress": "2001:8d8:1000:30ff:1bb6:8823:a9a3:a003",
+        "connection": "80"
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2014-01-26T18:37:47.701+01:00",
+        "time": 5010,
+        "request": {
+          "method": "GET",
+          "url": "http://www.sebastianstoehr.de/res/images/logo.png",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "www.sebastianstoehr.de"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0"
+            },
+            {
+              "name": "Accept",
+              "value": "image/png,image/*;q=0.8,*/*;q=0.5"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "de-de,de;q=0.8,en-us;q=0.5,en;q=0.3"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.sebastianstoehr.de/assets/app-176c7b354c124a4593b8d4ac674d69e6.css"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 710,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sun, 26 Jan 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Sat, 11 Jan 2014 10:56:55 GMT"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "717"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=15552000"
+            },
+            {
+              "name": "Expires",
+              "value": "Fri, 25 Jul 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Keep-Alive",
+              "value": "timeout=2, max=199"
+            },
+            {
+              "name": "Connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "image/png"
+            }
+          ],
+          "content": {
+            "mimeType": "image/png",
+            "size": 91,
+            "text": "Die Quelle von diesem URL ist kein Text:: http://www.sebastianstoehr.de/res/images/logo.png"
+          },
+          "redirectURL": "",
+          "headersSize": 315,
+          "bodySize": 717
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 5010,
+          "receive": 0
+        },
+        "serverIPAddress": "2001:8d8:1000:30ff:1bb6:8823:a9a3:a003",
+        "connection": "80"
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2014-01-26T18:37:47.701+01:00",
+        "time": 5032,
+        "request": {
+          "method": "GET",
+          "url": "http://www.sebastianstoehr.de/res/images/socialbar.png",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "www.sebastianstoehr.de"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0"
+            },
+            {
+              "name": "Accept",
+              "value": "image/png,image/*;q=0.8,*/*;q=0.5"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "de-de,de;q=0.8,en-us;q=0.5,en;q=0.3"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.sebastianstoehr.de/assets/app-176c7b354c124a4593b8d4ac674d69e6.css"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 715,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sun, 26 Jan 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Sat, 11 Jan 2014 10:56:55 GMT"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "2772"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=15552000"
+            },
+            {
+              "name": "Expires",
+              "value": "Fri, 25 Jul 2014 17:37:48 GMT"
+            },
+            {
+              "name": "Keep-Alive",
+              "value": "timeout=2, max=200"
+            },
+            {
+              "name": "Connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "image/png"
+            }
+          ],
+          "content": {
+            "mimeType": "image/png",
+            "size": 96,
+            "text": "Die Quelle von diesem URL ist kein Text:: http://www.sebastianstoehr.de/res/images/socialbar.png"
+          },
+          "redirectURL": "",
+          "headersSize": 316,
+          "bodySize": 2772
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0,
+          "dns": 0,
+          "connect": 29,
+          "send": 0,
+          "wait": 4980,
+          "receive": 23
+        },
+        "serverIPAddress": "2001:8d8:1000:30ff:1bb6:8823:a9a3:a003",
+        "connection": "80"
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2014-01-26T18:37:47.711+01:00",
+        "time": 5057,
+        "request": {
+          "method": "GET",
+          "url": "http://www.sebastianstoehr.de/assets/app-d6d60b5cc834e6a9ce6fbfee22da998f.js",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "www.sebastianstoehr.de"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0"
+            },
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "de-de,de;q=0.8,en-us;q=0.5,en;q=0.3"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.sebastianstoehr.de/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 660,
+          "bodySize": -1
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sun, 26 Jan 2014 17:37:53 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Fri, 10 Jan 2014 17:10:50 GMT"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "4453"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=15552000"
+            },
+            {
+              "name": "Expires",
+              "value": "Fri, 25 Jul 2014 17:37:53 GMT"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Keep-Alive",
+              "value": "timeout=2, max=198"
+            },
+            {
+              "name": "Connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/javascript"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            }
+          ],
+          "content": {
+            "mimeType": "text/javascript",
+            "size": 11676,
+            "text": "--- REMOVED ---\n"
+          },
+          "redirectURL": "",
+          "headersSize": 369,
+          "bodySize": 4453
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 5000,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 55,
+          "receive": 2
+        },
+        "serverIPAddress": "2001:8d8:1000:30ff:1bb6:8823:a9a3:a003",
+        "connection": "80"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I had a problem with a har file exported from Fiddler where the receive value in timings was 63596250212317. For my use case I don't care about this value and would be nice if the LAX mode could ignore Integer values that don't fit.