### PR TITLE
Support additional fields, which are not part of the official HAR spec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,13 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>3.5.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/de/sstoehr/harreader/model/HarCache.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCache.java
@@ -1,10 +1,14 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -18,6 +22,7 @@ public class HarCache {
     private HarCacheInfo beforeRequest;
     private HarCacheInfo afterRequest;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return State of the cache entry before the request, null if not present.
@@ -52,6 +57,19 @@ public class HarCache {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -59,12 +77,13 @@ public class HarCache {
         HarCache harCache = (HarCache) o;
         return Objects.equals(beforeRequest, harCache.beforeRequest) &&
                 Objects.equals(afterRequest, harCache.afterRequest) &&
-                Objects.equals(comment, harCache.comment);
+                Objects.equals(comment, harCache.comment) &&
+                Objects.equals(additional, harCache.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(beforeRequest, afterRequest, comment);
+        return Objects.hash(beforeRequest, afterRequest, comment, additional);
     }
 
     /**
@@ -80,6 +99,7 @@ public class HarCache {
         private String eTag;
         private Integer hitCount;
         private String comment;
+        private final Map<String, Object> additional = new HashMap<>();
 
         /**
          * @return Expiration time of entry, null if not present.
@@ -138,6 +158,19 @@ public class HarCache {
             this.comment = comment;
         }
 
+        /**
+         * @return Map with additional keys, which are not officially supported by the HAR specification
+         */
+        @JsonAnyGetter
+        public Map<String, Object> getAdditional() {
+            return additional;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalField(String key, Object value) {
+            this.additional.put(key, value);
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -147,12 +180,13 @@ public class HarCache {
                     Objects.equals(lastAccess, that.lastAccess) &&
                     Objects.equals(eTag, that.eTag) &&
                     Objects.equals(hitCount, that.hitCount) &&
-                    Objects.equals(comment, that.comment);
+                    Objects.equals(comment, that.comment)  &&
+                    Objects.equals(additional, that.additional);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(expires, lastAccess, eTag, hitCount, comment);
+            return Objects.hash(expires, lastAccess, eTag, hitCount, comment, additional);
         }
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarCache.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCache.java
@@ -73,7 +73,7 @@ public class HarCache {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarCache)) return false;
         HarCache harCache = (HarCache) o;
         return Objects.equals(beforeRequest, harCache.beforeRequest) &&
                 Objects.equals(afterRequest, harCache.afterRequest) &&
@@ -174,7 +174,7 @@ public class HarCache {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (!(o instanceof HarCacheInfo)) return false;
             HarCacheInfo that = (HarCacheInfo) o;
             return Objects.equals(expires, that.expires) &&
                     Objects.equals(lastAccess, that.lastAccess) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarContent.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarContent.java
@@ -1,8 +1,12 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -19,6 +23,7 @@ public class HarContent {
     private String text;
     private String encoding;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Length of returned content in bytes, null if not present.
@@ -88,6 +93,19 @@ public class HarContent {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -98,11 +116,12 @@ public class HarContent {
                 Objects.equals(mimeType, that.mimeType) &&
                 Objects.equals(text, that.text) &&
                 Objects.equals(encoding, that.encoding) &&
-                Objects.equals(comment, that.comment);
+                Objects.equals(comment, that.comment) &&
+                Objects.equals(additional, that.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(size, compression, mimeType, text, encoding, comment);
+        return Objects.hash(size, compression, mimeType, text, encoding, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarContent.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarContent.java
@@ -109,7 +109,7 @@ public class HarContent {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarContent)) return false;
         HarContent that = (HarContent) o;
         return Objects.equals(size, that.size) &&
                 Objects.equals(compression, that.compression) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarCookie.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCookie.java
@@ -134,7 +134,7 @@ public class HarCookie {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarCookie)) return false;
         HarCookie harCookie = (HarCookie) o;
         return Objects.equals(name, harCookie.name) &&
                 Objects.equals(value, harCookie.value) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarCookie.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCookie.java
@@ -1,10 +1,14 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -23,6 +27,7 @@ public class HarCookie {
     private Boolean httpOnly;
     private Boolean secure;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Name of the cookie, null if not present.
@@ -113,6 +118,19 @@ public class HarCookie {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -125,11 +143,12 @@ public class HarCookie {
                 Objects.equals(expires, harCookie.expires) &&
                 Objects.equals(httpOnly, harCookie.httpOnly) &&
                 Objects.equals(secure, harCookie.secure) &&
-                Objects.equals(comment, harCookie.comment);
+                Objects.equals(comment, harCookie.comment) &&
+                Objects.equals(additional, harCookie.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, value, path, domain, expires, httpOnly, secure, comment);
+        return Objects.hash(name, value, path, domain, expires, httpOnly, secure, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarCreatorBrowser.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCreatorBrowser.java
@@ -1,8 +1,12 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -16,6 +20,7 @@ public class HarCreatorBrowser {
     private String name;
     private String version;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Name of the application/browser used for creating HAR, null if not present.
@@ -50,6 +55,19 @@ public class HarCreatorBrowser {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -57,11 +75,12 @@ public class HarCreatorBrowser {
         HarCreatorBrowser that = (HarCreatorBrowser) o;
         return Objects.equals(name, that.name) &&
                 Objects.equals(version, that.version) &&
-                Objects.equals(comment, that.comment);
+                Objects.equals(comment, that.comment) &&
+                Objects.equals(additional, that.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, version, comment);
+        return Objects.hash(name, version, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarCreatorBrowser.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCreatorBrowser.java
@@ -71,7 +71,7 @@ public class HarCreatorBrowser {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarCreatorBrowser)) return false;
         HarCreatorBrowser that = (HarCreatorBrowser) o;
         return Objects.equals(name, that.name) &&
                 Objects.equals(version, that.version) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarEntry.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarEntry.java
@@ -170,7 +170,7 @@ public class HarEntry {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarEntry)) return false;
         HarEntry harEntry = (HarEntry) o;
         return Objects.equals(pageref, harEntry.pageref) &&
                 Objects.equals(startedDateTime, harEntry.startedDateTime) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarEntry.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarEntry.java
@@ -29,7 +29,7 @@ public class HarEntry {
     private String serverIPAddress;
     private String connection;
     private String comment;
-    private Map<String, Object> additional = new HashMap<>();
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Reference to parent page, to which the request belongs to, null if not present.
@@ -154,14 +154,17 @@ public class HarEntry {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
     @JsonAnyGetter
     public Map<String, Object> getAdditional() {
         return additional;
     }
 
     @JsonAnySetter
-    public void setAdditionalField(String name, Object value) {
-        this.additional.put(name, value);
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
     }
 
     @Override

--- a/src/main/java/de/sstoehr/harreader/model/HarHeader.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarHeader.java
@@ -71,7 +71,7 @@ public class HarHeader {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarHeader)) return false;
         HarHeader harHeader = (HarHeader) o;
         return Objects.equals(name, harHeader.name) &&
                 Objects.equals(value, harHeader.value) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarHeader.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarHeader.java
@@ -1,8 +1,12 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -16,6 +20,7 @@ public class HarHeader {
     private String name;
     private String value;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Header name, null if not present.
@@ -50,6 +55,19 @@ public class HarHeader {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -57,11 +75,12 @@ public class HarHeader {
         HarHeader harHeader = (HarHeader) o;
         return Objects.equals(name, harHeader.name) &&
                 Objects.equals(value, harHeader.value) &&
-                Objects.equals(comment, harHeader.comment);
+                Objects.equals(comment, harHeader.comment) &&
+                Objects.equals(additional, harHeader.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, value, comment);
+        return Objects.hash(name, value, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarLog.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarLog.java
@@ -1,10 +1,14 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -23,6 +27,7 @@ public class HarLog {
     private List<HarPage> pages = new ArrayList<>();
     private List<HarEntry> entries = new ArrayList<>();
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Version number of the format.
@@ -106,6 +111,19 @@ public class HarLog {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -116,11 +134,12 @@ public class HarLog {
                 Objects.equals(browser, harLog.browser) &&
                 Objects.equals(pages, harLog.pages) &&
                 Objects.equals(entries, harLog.entries) &&
-                Objects.equals(comment, harLog.comment);
+                Objects.equals(comment, harLog.comment) &&
+                Objects.equals(additional, harLog.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(version, creator, browser, pages, entries, comment);
+        return Objects.hash(version, creator, browser, pages, entries, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarLog.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarLog.java
@@ -127,7 +127,7 @@ public class HarLog {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarLog)) return false;
         HarLog harLog = (HarLog) o;
         return Objects.equals(version, harLog.version) &&
                 Objects.equals(creator, harLog.creator) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarPage.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPage.java
@@ -101,7 +101,7 @@ public class HarPage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarPage)) return false;
         HarPage harPage = (HarPage) o;
         return Objects.equals(startedDateTime, harPage.startedDateTime) &&
                 Objects.equals(id, harPage.id) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarPage.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPage.java
@@ -24,7 +24,7 @@ public class HarPage {
     private String title;
     private HarPageTiming pageTimings;
     private String comment;
-    private Map<String, Object> additional = new HashMap<>();
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Start time of page load, null if not present.
@@ -85,14 +85,17 @@ public class HarPage {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
     @JsonAnyGetter
     public Map<String, Object> getAdditional() {
         return additional;
     }
 
     @JsonAnySetter
-    public void setAdditionalField(String name, Object value) {
-        this.additional.put(name, value);
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
     }
 
     @Override

--- a/src/main/java/de/sstoehr/harreader/model/HarPageTiming.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPageTiming.java
@@ -1,8 +1,12 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -18,6 +22,7 @@ public class HarPageTiming {
     private Integer onContentLoad = DEFAULT_TIME;
     private Integer onLoad = DEFAULT_TIME;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Duration in ms until content is loaded.
@@ -60,6 +65,19 @@ public class HarPageTiming {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -67,11 +85,12 @@ public class HarPageTiming {
         HarPageTiming that = (HarPageTiming) o;
         return Objects.equals(onContentLoad, that.onContentLoad) &&
                 Objects.equals(onLoad, that.onLoad) &&
-                Objects.equals(comment, that.comment);
+                Objects.equals(comment, that.comment) &&
+                Objects.equals(additional, that.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(onContentLoad, onLoad, comment);
+        return Objects.hash(onContentLoad, onLoad, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarPageTiming.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPageTiming.java
@@ -81,7 +81,7 @@ public class HarPageTiming {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarPageTiming)) return false;
         HarPageTiming that = (HarPageTiming) o;
         return Objects.equals(onContentLoad, that.onContentLoad) &&
                 Objects.equals(onLoad, that.onLoad) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarPostData.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPostData.java
@@ -1,10 +1,14 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -19,6 +23,7 @@ public class HarPostData {
     private List<HarPostDataParam> params = new ArrayList<>();
     private String text;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return MIME type of posted data, null if not present.
@@ -67,6 +72,19 @@ public class HarPostData {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -75,11 +93,12 @@ public class HarPostData {
         return Objects.equals(mimeType, that.mimeType) &&
                 Objects.equals(params, that.params) &&
                 Objects.equals(text, that.text) &&
-                Objects.equals(comment, that.comment);
+                Objects.equals(comment, that.comment) &&
+                Objects.equals(additional, that.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mimeType, params, text, comment);
+        return Objects.hash(mimeType, params, text, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarPostData.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPostData.java
@@ -88,7 +88,7 @@ public class HarPostData {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarPostData)) return false;
         HarPostData that = (HarPostData) o;
         return Objects.equals(mimeType, that.mimeType) &&
                 Objects.equals(params, that.params) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarPostDataParam.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPostDataParam.java
@@ -95,7 +95,7 @@ public class HarPostDataParam {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarPostDataParam)) return false;
         HarPostDataParam that = (HarPostDataParam) o;
         return Objects.equals(name, that.name) &&
                 Objects.equals(value, that.value) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarPostDataParam.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPostDataParam.java
@@ -1,8 +1,12 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -18,6 +22,7 @@ public class HarPostDataParam {
     private String fileName;
     private String contentType;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Name of param, null if not present.
@@ -74,6 +79,19 @@ public class HarPostDataParam {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -83,11 +101,12 @@ public class HarPostDataParam {
                 Objects.equals(value, that.value) &&
                 Objects.equals(fileName, that.fileName) &&
                 Objects.equals(contentType, that.contentType) &&
-                Objects.equals(comment, that.comment);
+                Objects.equals(comment, that.comment) &&
+                Objects.equals(additional, that.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, value, fileName, contentType, comment);
+        return Objects.hash(name, value, fileName, contentType, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarQueryParam.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarQueryParam.java
@@ -71,7 +71,7 @@ public class HarQueryParam {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarQueryParam)) return false;
         HarQueryParam that = (HarQueryParam) o;
         return Objects.equals(name, that.name) &&
                 Objects.equals(value, that.value) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarQueryParam.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarQueryParam.java
@@ -1,8 +1,12 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -16,6 +20,7 @@ public class HarQueryParam {
     private String name;
     private String value;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Name of param, null if not present.
@@ -50,6 +55,19 @@ public class HarQueryParam {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -57,11 +75,12 @@ public class HarQueryParam {
         HarQueryParam that = (HarQueryParam) o;
         return Objects.equals(name, that.name) &&
                 Objects.equals(value, that.value) &&
-                Objects.equals(comment, that.comment);
+                Objects.equals(comment, that.comment) &&
+                Objects.equals(additional, that.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, value, comment);
+        return Objects.hash(name, value, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarRequest.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarRequest.java
@@ -31,7 +31,7 @@ public class HarRequest {
     private Long headersSize;
     private Long bodySize;
     private String comment;
-    private Map<String, Object> additional = new HashMap<>();
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Request method, null if not present.
@@ -163,14 +163,17 @@ public class HarRequest {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
     @JsonAnyGetter
     public Map<String, Object> getAdditional() {
         return additional;
     }
 
     @JsonAnySetter
-    public void setAdditionalField(String name, Object value) {
-        this.additional.put(name, value);
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
     }
 
     @Override

--- a/src/main/java/de/sstoehr/harreader/model/HarRequest.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarRequest.java
@@ -179,7 +179,7 @@ public class HarRequest {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarRequest)) return false;
         HarRequest that = (HarRequest) o;
         return method == that.method &&
                 Objects.equals(url, that.url) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarResponse.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarResponse.java
@@ -27,7 +27,7 @@ public class HarResponse {
     private Long headersSize;
     private Long bodySize;
     private String comment;
-    private Map<String, Object> additional = new HashMap<>();
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Response status, null if not present.
@@ -160,14 +160,17 @@ public class HarResponse {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
     @JsonAnyGetter
     public Map<String, Object> getAdditional() {
         return additional;
     }
 
     @JsonAnySetter
-    public void setAdditionalField(String name, Object value) {
-        this.additional.put(name, value);
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
     }
 
     @Override

--- a/src/main/java/de/sstoehr/harreader/model/HarResponse.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarResponse.java
@@ -176,7 +176,7 @@ public class HarResponse {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarResponse)) return false;
         HarResponse that = (HarResponse) o;
         return status == that.status &&
                 Objects.equals(statusText, that.statusText) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarTiming.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarTiming.java
@@ -147,7 +147,7 @@ public class HarTiming {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof HarTiming)) return false;
         HarTiming harTiming = (HarTiming) o;
         return Objects.equals(blocked, harTiming.blocked) &&
                 Objects.equals(dns, harTiming.dns) &&

--- a/src/main/java/de/sstoehr/harreader/model/HarTiming.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarTiming.java
@@ -1,8 +1,12 @@
 package de.sstoehr.harreader.model;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -19,6 +23,7 @@ public class HarTiming {
     private Integer receive;
     private Integer ssl;
     private String comment;
+    private final Map<String, Object> additional = new HashMap<>();
 
     /**
      * @return Time spent in a queue waiting for a network connection.
@@ -126,6 +131,19 @@ public class HarTiming {
         this.comment = comment;
     }
 
+    /**
+     * @return Map with additional keys, which are not officially supported by the HAR specification
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getAdditional() {
+        return additional;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalField(String key, Object value) {
+        this.additional.put(key, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -138,11 +156,12 @@ public class HarTiming {
                 Objects.equals(wait, harTiming.wait) &&
                 Objects.equals(receive, harTiming.receive) &&
                 Objects.equals(ssl, harTiming.ssl) &&
-                Objects.equals(comment, harTiming.comment);
+                Objects.equals(comment, harTiming.comment) &&
+                Objects.equals(additional, harTiming.additional);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(blocked, dns, connect, send, wait, receive, ssl, comment);
+        return Objects.hash(blocked, dns, connect, send, wait, receive, ssl, comment, additional);
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarCacheTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCacheTest.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.Date;
 
@@ -37,4 +39,9 @@ public class HarCacheTest extends AbstractMapperTest<HarCache> {
 
     }
 
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarCache.class).verify();
+        EqualsVerifier.simple().forClass(HarCache.HarCacheInfo.class).verify();
+    }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarCacheTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCacheTest.java
@@ -16,7 +16,7 @@ public class HarCacheTest extends AbstractMapperTest<HarCache> {
     @Override
     public void testMapping() {
         HarCache cache = map("{\"beforeRequest\":{\"expires\":\"2014-01-01T12:00:00\",\"lastAccess\":\"2013-06-01T12:00:00\",\"eTag\":\"abc123\"," +
-        "\"hitCount\":3,\"comment\":\"my comment\"},\"afterRequest\":{},\"comment\":\"my comment 2\"}", HarCache.class);
+        "\"hitCount\":3,\"comment\":\"my comment\"},\"afterRequest\":{},\"comment\":\"my comment 2\",\"_unknown\":\"unknown\"}", HarCache.class);
 
         Assert.assertNotNull(cache.getBeforeRequest());
         Assert.assertEquals(EXPECTED_EXPIRES, cache.getBeforeRequest().getExpires());
@@ -28,6 +28,9 @@ public class HarCacheTest extends AbstractMapperTest<HarCache> {
         Assert.assertNotNull(cache.getAfterRequest());
 
         Assert.assertEquals("my comment 2", cache.getComment());
+
+        Assert.assertNotNull(cache.getAdditional());
+        Assert.assertEquals("unknown", cache.getAdditional().get("_unknown"));
 
         cache = map(UNKNOWN_PROPERTY, HarCache.class);
         Assert.assertNotNull(cache);

--- a/src/test/java/de/sstoehr/harreader/model/HarContentTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarContentTest.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class HarContentTest extends AbstractMapperTest<HarContent> {
 
@@ -21,6 +23,11 @@ public class HarContentTest extends AbstractMapperTest<HarContent> {
 
         content = map(UNKNOWN_PROPERTY, HarContent.class);
         Assert.assertNotNull(content);
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarContent.class).verify();
     }
 
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarContentTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarContentTest.java
@@ -7,7 +7,7 @@ public class HarContentTest extends AbstractMapperTest<HarContent> {
     @Override
     public void testMapping() {
         HarContent content = map("{\"size\":123,\"compression\":45,\"mimeType\":\"mime/type\"," +
-        "\"text\":\"my content\",\"encoding\":\"base64\",\"comment\":\"my comment\"}", HarContent.class);
+        "\"text\":\"my content\",\"encoding\":\"base64\",\"comment\":\"my comment\",\"_unknown\":\"unknown\"}", HarContent.class);
 
         Assert.assertEquals(123L, (long) content.getSize());
         Assert.assertEquals(45L, (long) content.getCompression());
@@ -15,6 +15,9 @@ public class HarContentTest extends AbstractMapperTest<HarContent> {
         Assert.assertEquals("my content", content.getText());
         Assert.assertEquals("base64", content.getEncoding());
         Assert.assertEquals("my comment", content.getComment());
+
+        Assert.assertNotNull(content.getAdditional());
+        Assert.assertEquals("unknown", content.getAdditional().get("_unknown"));
 
         content = map(UNKNOWN_PROPERTY, HarContent.class);
         Assert.assertNotNull(content);

--- a/src/test/java/de/sstoehr/harreader/model/HarCookieTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCookieTest.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.Date;
 
@@ -32,4 +34,8 @@ public class HarCookieTest extends AbstractMapperTest<HarCookie> {
         Assert.assertNotNull(cookie);
     }
 
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarCookie.class).verify();
+    }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarCookieTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCookieTest.java
@@ -13,7 +13,7 @@ public class HarCookieTest extends AbstractMapperTest<HarCookie> {
     @Override
     public void testMapping() {
         HarCookie cookie = map("{\"name\":\"aName\",\"value\":\"aValue\",\"path\":\"/\",\"domain\":\"sstoehr.de\"," +
-    "\"expires\":\"2014-01-01T12:00:00\",\"httpOnly\":\"true\",\"secure\":\"false\",\"comment\":\"my comment\"}", HarCookie.class);
+    "\"expires\":\"2014-01-01T12:00:00\",\"httpOnly\":\"true\",\"secure\":\"false\",\"comment\":\"my comment\",\"_unknown\":\"unknown\"}", HarCookie.class);
 
         Assert.assertNotNull(cookie);
         Assert.assertEquals("aName", cookie.getName());
@@ -24,6 +24,9 @@ public class HarCookieTest extends AbstractMapperTest<HarCookie> {
         Assert.assertEquals(true, cookie.getHttpOnly());
         Assert.assertEquals(false, cookie.getSecure());
         Assert.assertEquals("my comment", cookie.getComment());
+
+        Assert.assertNotNull(cookie.getAdditional());
+        Assert.assertEquals("unknown", cookie.getAdditional().get("_unknown"));
 
         cookie = map(UNKNOWN_PROPERTY, HarCookie.class);
         Assert.assertNotNull(cookie);

--- a/src/test/java/de/sstoehr/harreader/model/HarCreatorBrowserTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCreatorBrowserTest.java
@@ -6,12 +6,15 @@ public class HarCreatorBrowserTest extends AbstractMapperTest<HarCreatorBrowser>
 
     @Override
     public void testMapping() {
-        HarCreatorBrowser creatorBrowser = map("{\"name\":\"aName\",\"version\":\"aVersion\",\"comment\":\"my comment\"}", HarCreatorBrowser.class);
+        HarCreatorBrowser creatorBrowser = map("{\"name\":\"aName\",\"version\":\"aVersion\",\"comment\":\"my comment\",\"_unknown\":\"unknown\"}", HarCreatorBrowser.class);
 
         Assert.assertNotNull(creatorBrowser);
         Assert.assertEquals("aName", creatorBrowser.getName());
         Assert.assertEquals("aVersion", creatorBrowser.getVersion());
         Assert.assertEquals("my comment", creatorBrowser.getComment());
+
+        Assert.assertNotNull(creatorBrowser.getAdditional());
+        Assert.assertEquals("unknown", creatorBrowser.getAdditional().get("_unknown"));
 
         creatorBrowser = map(UNKNOWN_PROPERTY, HarCreatorBrowser.class);
         Assert.assertNotNull(creatorBrowser);

--- a/src/test/java/de/sstoehr/harreader/model/HarCreatorBrowserTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCreatorBrowserTest.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class HarCreatorBrowserTest extends AbstractMapperTest<HarCreatorBrowser> {
 
@@ -18,6 +20,11 @@ public class HarCreatorBrowserTest extends AbstractMapperTest<HarCreatorBrowser>
 
         creatorBrowser = map(UNKNOWN_PROPERTY, HarCreatorBrowser.class);
         Assert.assertNotNull(creatorBrowser);
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarCreatorBrowser.class).verify();
     }
 
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarEntryTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarEntryTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -60,5 +61,10 @@ public class HarEntryTest extends AbstractMapperTest<HarEntry> {
         HarEntry entry = new HarEntry();
         entry.setTimings(null);
         Assert.assertNotNull(entry.getTimings());
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarEntry.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarHeaderTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarHeaderTest.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class HarHeaderTest extends AbstractMapperTest<HarHeader> {
 
@@ -20,4 +22,8 @@ public class HarHeaderTest extends AbstractMapperTest<HarHeader> {
         Assert.assertNotNull(header);
     }
 
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarHeader.class).verify();
+    }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarHeaderTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarHeaderTest.java
@@ -6,12 +6,15 @@ public class HarHeaderTest extends AbstractMapperTest<HarHeader> {
 
     @Override
     public void testMapping() {
-        HarHeader header = map("{\"name\":\"aName\",\"value\":\"aValue\",\"comment\":\"my comment\"}", HarHeader.class);
+        HarHeader header = map("{\"name\":\"aName\",\"value\":\"aValue\",\"comment\":\"my comment\",\"_unknown\":\"unknown\"}", HarHeader.class);
 
         Assert.assertNotNull(header);
         Assert.assertEquals("aName", header.getName());
         Assert.assertEquals("aValue", header.getValue());
         Assert.assertEquals("my comment", header.getComment());
+
+        Assert.assertNotNull(header.getAdditional());
+        Assert.assertEquals("unknown", header.getAdditional().get("_unknown"));
 
         header = map(UNKNOWN_PROPERTY, HarHeader.class);
         Assert.assertNotNull(header);

--- a/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
@@ -64,7 +64,7 @@ public class HarLogTest extends AbstractMapperTest<HarLog> {
 
     @Override
     public void testMapping() {
-        HarLog log = map("{\"creator\": {}, \"browser\": {}, \"comment\": \"My comment\"}", HarLog.class);
+        HarLog log = map("{\"creator\": {}, \"browser\": {}, \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarLog.class);
 
         Assert.assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
         Assert.assertNotNull(log.getCreator());
@@ -72,6 +72,9 @@ public class HarLogTest extends AbstractMapperTest<HarLog> {
         Assert.assertEquals(EXPECTED_PAGES_LIST, log.getPages());
         Assert.assertEquals(EXPECTED_ENTRIES_LIST, log.getEntries());
         Assert.assertEquals("My comment", log.getComment());
+
+        Assert.assertNotNull(log.getAdditional());
+        Assert.assertEquals("unknown", log.getAdditional().get("_unknown"));
 
         log = map(UNKNOWN_PROPERTY, HarLog.class);
         Assert.assertNotNull(log);

--- a/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -78,5 +79,10 @@ public class HarLogTest extends AbstractMapperTest<HarLog> {
 
         log = map(UNKNOWN_PROPERTY, HarLog.class);
         Assert.assertNotNull(log);
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarLog.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarPageTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPageTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,5 +34,10 @@ public class HarPageTest extends AbstractMapperTest<HarPage> {
         HarPage page = new HarPage();
         page.setPageTimings(null);
         Assert.assertNotNull(page.getPageTimings());
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarPage.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarPageTimingTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPageTimingTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -44,5 +45,10 @@ public class HarPageTimingTest extends AbstractMapperTest<HarPageTiming> {
 
         pageTiming = map(UNKNOWN_PROPERTY, HarPageTiming.class);
         Assert.assertNotNull(pageTiming);
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarPageTiming.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarPageTimingTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPageTimingTest.java
@@ -33,11 +33,14 @@ public class HarPageTimingTest extends AbstractMapperTest<HarPageTiming> {
 
     @Override
     public void testMapping() {
-        HarPageTiming pageTiming = map("{\"onContentLoad\": 1234, \"onLoad\": 5678, \"comment\": \"My comment\"}", HarPageTiming.class);
+        HarPageTiming pageTiming = map("{\"onContentLoad\": 1234, \"onLoad\": 5678, \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarPageTiming.class);
 
         Assert.assertEquals(1234, (int) pageTiming.getOnContentLoad());
         Assert.assertEquals(5678, (int) pageTiming.getOnLoad());
         Assert.assertEquals("My comment", pageTiming.getComment());
+
+        Assert.assertNotNull(pageTiming.getAdditional());
+        Assert.assertEquals("unknown", pageTiming.getAdditional().get("_unknown"));
 
         pageTiming = map(UNKNOWN_PROPERTY, HarPageTiming.class);
         Assert.assertNotNull(pageTiming);

--- a/src/test/java/de/sstoehr/harreader/model/HarPostDataParamTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPostDataParamTest.java
@@ -6,7 +6,7 @@ public class HarPostDataParamTest extends AbstractMapperTest<HarPostDataParam> {
 
     @Override
     public void testMapping() {
-        HarPostDataParam postDataParam = map("{\"name\": \"aName\", \"value\": \"aValue\", \"fileName\": \"aFilename\", \"contentType\": \"aContentType\", \"comment\": \"My comment\"}", HarPostDataParam.class);
+        HarPostDataParam postDataParam = map("{\"name\": \"aName\", \"value\": \"aValue\", \"fileName\": \"aFilename\", \"contentType\": \"aContentType\", \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarPostDataParam.class);
 
         Assert.assertEquals("aName", postDataParam.getName());
         Assert.assertEquals("aValue", postDataParam.getValue());
@@ -14,6 +14,8 @@ public class HarPostDataParamTest extends AbstractMapperTest<HarPostDataParam> {
         Assert.assertEquals("aContentType", postDataParam.getContentType());
         Assert.assertEquals("My comment", postDataParam.getComment());
 
+        Assert.assertNotNull(postDataParam.getAdditional());
+        Assert.assertEquals("unknown", postDataParam.getAdditional().get("_unknown"));
 
         postDataParam = map(UNKNOWN_PROPERTY, HarPostDataParam.class);
         Assert.assertNotNull(postDataParam);

--- a/src/test/java/de/sstoehr/harreader/model/HarPostDataParamTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPostDataParamTest.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class HarPostDataParamTest extends AbstractMapperTest<HarPostDataParam> {
 
@@ -19,6 +21,11 @@ public class HarPostDataParamTest extends AbstractMapperTest<HarPostDataParam> {
 
         postDataParam = map(UNKNOWN_PROPERTY, HarPostDataParam.class);
         Assert.assertNotNull(postDataParam);
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarPostDataParam.class).verify();
     }
 
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarPostDataTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPostDataTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,5 +32,10 @@ public class HarPostDataTest extends AbstractMapperTest<HarPostData> {
         HarPostData postData = new HarPostData();
         postData.setParams(null);
         Assert.assertNotNull(postData.getParams());
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarPostData.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarPostDataTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPostDataTest.java
@@ -12,12 +12,15 @@ public class HarPostDataTest extends AbstractMapperTest<HarPostData> {
 
     @Override
     public void testMapping() {
-        HarPostData postData = map("{\"mimeType\": \"aMimeType\", \"params\": [], \"text\":\"aText\", \"comment\": \"My comment\"}", HarPostData.class);
+        HarPostData postData = map("{\"mimeType\": \"aMimeType\", \"params\": [], \"text\":\"aText\", \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarPostData.class);
 
         Assert.assertEquals("aMimeType", postData.getMimeType());
         Assert.assertEquals(EXPECTED_LIST, postData.getParams());
         Assert.assertEquals("aText", postData.getText());
         Assert.assertEquals("My comment", postData.getComment());
+
+        Assert.assertNotNull(postData.getAdditional());
+        Assert.assertEquals("unknown", postData.getAdditional().get("_unknown"));
 
         postData = map(UNKNOWN_PROPERTY, HarPostData.class);
         Assert.assertNotNull(postData);

--- a/src/test/java/de/sstoehr/harreader/model/HarQueryParamTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarQueryParamTest.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class HarQueryParamTest extends AbstractMapperTest<HarQueryParam> {
 
@@ -16,4 +18,8 @@ public class HarQueryParamTest extends AbstractMapperTest<HarQueryParam> {
         Assert.assertEquals("unknown", queryParam.getAdditional().get("_unknown"));
     }
 
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarQueryParam.class).verify();
+    }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarQueryParamTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarQueryParamTest.java
@@ -6,11 +6,14 @@ public class HarQueryParamTest extends AbstractMapperTest<HarQueryParam> {
 
     @Override
     public void testMapping() {
-        HarQueryParam queryParam = map("{\"name\": \"aName\", \"value\":\"aValue\", \"comment\": \"My comment\"}", HarQueryParam.class);
+        HarQueryParam queryParam = map("{\"name\": \"aName\", \"value\":\"aValue\", \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarQueryParam.class);
 
         Assert.assertEquals("aName", queryParam.getName());
         Assert.assertEquals("aValue", queryParam.getValue());
         Assert.assertEquals("My comment", queryParam.getComment());
+
+        Assert.assertNotNull(queryParam.getAdditional());
+        Assert.assertEquals("unknown", queryParam.getAdditional().get("_unknown"));
     }
 
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -67,5 +68,10 @@ public class HarRequestTest extends AbstractMapperTest<HarRequest> {
         HarRequest request = new HarRequest();
         request.setBodySize(null);
         Assert.assertEquals(-1L, (long) request.getBodySize());
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarRequest.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -64,5 +65,10 @@ public class HarResponseTest extends AbstractMapperTest<HarResponse> {
         HarResponse response = new HarResponse();
         response.setBodySize(null);
         Assert.assertEquals(-1L, (long) response.getBodySize());
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarResponse.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -19,6 +20,11 @@ public class HarTest extends AbstractMapperTest<Har>{
 
         har = map(UNKNOWN_PROPERTY, Har.class);
         Assert.assertNotNull(har);
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(Har.class).verify();
     }
 
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarTimingTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarTimingTest.java
@@ -1,5 +1,6 @@
 package de.sstoehr.harreader.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,5 +51,10 @@ public class HarTimingTest extends AbstractMapperTest<HarTiming> {
         HarTiming timing = new HarTiming();
         timing.setSsl(null);
         Assert.assertEquals(-1, (int) timing.getSsl());
+    }
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.simple().forClass(HarTiming.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarTimingTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarTimingTest.java
@@ -8,7 +8,7 @@ public class HarTimingTest extends AbstractMapperTest<HarTiming> {
     @Override
     public void testMapping() {
         HarTiming timing = map("{\"blocked\": 3804,\"dns\": 23,\"connect\": 5,\"send\": 9,\"wait\": 5209,"
-        + "\"receive\": 79, \"ssl\": 123, \"comment\": \"my comment\"}", HarTiming.class);
+        + "\"receive\": 79, \"ssl\": 123, \"comment\": \"my comment\",\"_unknown\":\"unknown\"}", HarTiming.class);
 
         Assert.assertNotNull(timing);
         Assert.assertEquals(3804, (int) timing.getBlocked());
@@ -19,6 +19,9 @@ public class HarTimingTest extends AbstractMapperTest<HarTiming> {
         Assert.assertEquals(79, (int) timing.getReceive());
         Assert.assertEquals(123, (int) timing.getSsl());
         Assert.assertEquals("my comment", timing.getComment());
+
+        Assert.assertNotNull(timing.getAdditional());
+        Assert.assertEquals("unknown", timing.getAdditional().get("_unknown"));
     }
 
     @Test


### PR DESCRIPTION
There are different applications, which add custom fields to HAR files, which are not officially supported by the spec.
Right now HAR Reader is just ignoring these fields. With this change these fields can be accessed using a `Map<String, Object>`. 

**Reasons for this implementation:**

HAR reader should focus on the official spec - thus we are not integrating support for fields, which are not part of the spec.
As some applications might need to access these fields, HAR reader will grant access to the field in a low level, simple way.
Applications need to check and cast these fields (if needed).