### PR TITLE
Update dependencies and java target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .idea/
 *.iml
 target/
+
+#Eclipse
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.16.0</jackson.version>
     </properties>
 
     <dependencies>
@@ -36,9 +36,9 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -56,7 +56,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>7</release>
+                    <release>8</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -64,7 +64,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.6.2</version>
                 <configuration>
-                    <source>1.7</source>
+                    <source>1.8</source>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/de/sstoehr/harreader/HarReaderTest.java
+++ b/src/test/java/de/sstoehr/harreader/HarReaderTest.java
@@ -1,72 +1,76 @@
 package de.sstoehr.harreader;
 
 import de.sstoehr.harreader.model.Har;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
-public class HarReaderTest {
+import org.junit.jupiter.api.Test;
+
+class HarReaderTest {
 
     private HarReader harReader = new HarReader();
 
     @Test
-    public void test() throws HarReaderException {
+    void test() throws HarReaderException {
         File harFile = new File("src/test/resources/sstoehr.har");
         Har har = harReader.readFromFile(harFile);
-        Assert.assertNotNull(har);
+        assertNotNull(har);
     }
 
     @Test
-    public void missingLog() throws HarReaderException {
+    void missingLog() throws HarReaderException {
         Har har = harReader.readFromString("{\"unknown\":\"!\"}");
-        Assert.assertNotNull(har);
-    }
-
-    @Test(expected = HarReaderException.class)
-    public void invalidDateStrict() throws HarReaderException {
-        File harFile = new File("src/test/resources/sstoehr.invalid-date.har");
-        harReader.readFromFile(harFile);
+        assertNotNull(har);
     }
 
     @Test
-    public void invalidDateLax() throws HarReaderException {
+    void invalidDateStrict() throws HarReaderException {
+        File harFile = new File("src/test/resources/sstoehr.invalid-date.har");
+        assertThrows(HarReaderException.class, () -> harReader.readFromFile(harFile));
+    }
+
+    @Test
+    void invalidDateLax() throws HarReaderException {
         File harFile = new File("src/test/resources/sstoehr.invalid-date.har");
         Har har = harReader.readFromFile(harFile, HarReaderMode.LAX);
-        Assert.assertNotNull(har);
-    }
-
-    @Test(expected = HarReaderException.class)
-    public void invalidIntegerStrict() throws HarReaderException {
-        File harFile = new File("src/test/resources/sstoehr.invalid-integer.har");
-        harReader.readFromFile(harFile);
+        assertNotNull(har);
     }
 
     @Test
-    public void invalidIntegerLax() throws HarReaderException {
+    void invalidIntegerStrict() throws HarReaderException {
+        File harFile = new File("src/test/resources/sstoehr.invalid-integer.har");
+        assertThrows(HarReaderException.class, () -> harReader.readFromFile(harFile));
+    }
+
+    @Test
+    void invalidIntegerLax() throws HarReaderException {
         File harFile = new File("src/test/resources/sstoehr.invalid-integer.har");
         Har har = harReader.readFromFile(harFile, HarReaderMode.LAX);
-        Assert.assertNotNull(har);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void mapperFactoryNotNull() {
-        new HarReader(null);
+        assertNotNull(har);
     }
 
     @Test
-    public void testEquals() throws HarReaderException {
+    void mapperFactoryNotNull() {
+        assertThrows(IllegalArgumentException.class, () -> new HarReader(null));
+    }
+
+    @Test
+    void testEquals() throws HarReaderException {
         File harFile = new File("src/test/resources/sstoehr.har");
         Har har1 = harReader.readFromFile(harFile);
         Har har2 = harReader.readFromFile(harFile);
-        Assert.assertTrue(har1.equals(har2));
+        assertTrue(har1.equals(har2));
     }
 
     @Test
-    public void testHashCode() throws HarReaderException {
+    void testHashCode() throws HarReaderException {
         File harFile = new File("src/test/resources/sstoehr.har");
         Har har1 = harReader.readFromFile(harFile);
         Har har2 = harReader.readFromFile(harFile);
-        Assert.assertEquals(har1.hashCode(), har2.hashCode());
+        assertEquals(har1.hashCode(), har2.hashCode());
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/AbstractMapperTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/AbstractMapperTest.java
@@ -1,22 +1,24 @@
 package de.sstoehr.harreader.model;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
 
 public abstract class AbstractMapperTest<T> {
 
     protected final static String UNKNOWN_PROPERTY = "{\"unknownProperty\":\"value\"}";
 
     @Test
-    public abstract void testMapping();
+    abstract void testMapping();
 
     public T map(String input, Class<T> tClass) {
         ObjectMapper mapper = new ObjectMapper();
         try {
             return mapper.readValue(input, tClass);
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            fail(e.getMessage());
         }
         return null;
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarCacheTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCacheTest.java
@@ -1,12 +1,14 @@
 package de.sstoehr.harreader.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Date;
 
-public class HarCacheTest extends AbstractMapperTest<HarCache> {
+import org.junit.jupiter.api.Test;
+
+class HarCacheTest extends AbstractMapperTest<HarCache> {
 
     private final static Date EXPECTED_EXPIRES = new Date() {{
         setTime(1388577600000L);
@@ -20,27 +22,27 @@ public class HarCacheTest extends AbstractMapperTest<HarCache> {
         HarCache cache = map("{\"beforeRequest\":{\"expires\":\"2014-01-01T12:00:00\",\"lastAccess\":\"2013-06-01T12:00:00\",\"eTag\":\"abc123\"," +
         "\"hitCount\":3,\"comment\":\"my comment\"},\"afterRequest\":{},\"comment\":\"my comment 2\",\"_unknown\":\"unknown\"}", HarCache.class);
 
-        Assert.assertNotNull(cache.getBeforeRequest());
-        Assert.assertEquals(EXPECTED_EXPIRES, cache.getBeforeRequest().getExpires());
-        Assert.assertEquals(EXPECTED_LAST_ACCESS, cache.getBeforeRequest().getLastAccess());
-        Assert.assertEquals("abc123", cache.getBeforeRequest().geteTag());
-        Assert.assertEquals(3, (long) cache.getBeforeRequest().getHitCount());
-        Assert.assertEquals("my comment", cache.getBeforeRequest().getComment());
+        assertNotNull(cache.getBeforeRequest());
+        assertEquals(EXPECTED_EXPIRES, cache.getBeforeRequest().getExpires());
+        assertEquals(EXPECTED_LAST_ACCESS, cache.getBeforeRequest().getLastAccess());
+        assertEquals("abc123", cache.getBeforeRequest().geteTag());
+        assertEquals(3, (long) cache.getBeforeRequest().getHitCount());
+        assertEquals("my comment", cache.getBeforeRequest().getComment());
 
-        Assert.assertNotNull(cache.getAfterRequest());
+        assertNotNull(cache.getAfterRequest());
 
-        Assert.assertEquals("my comment 2", cache.getComment());
+        assertEquals("my comment 2", cache.getComment());
 
-        Assert.assertNotNull(cache.getAdditional());
-        Assert.assertEquals("unknown", cache.getAdditional().get("_unknown"));
+        assertNotNull(cache.getAdditional());
+        assertEquals("unknown", cache.getAdditional().get("_unknown"));
 
         cache = map(UNKNOWN_PROPERTY, HarCache.class);
-        Assert.assertNotNull(cache);
+        assertNotNull(cache);
 
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarCache.class).verify();
         EqualsVerifier.simple().forClass(HarCache.HarCacheInfo.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarContentTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarContentTest.java
@@ -1,32 +1,35 @@
 package de.sstoehr.harreader.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class HarContentTest extends AbstractMapperTest<HarContent> {
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class HarContentTest extends AbstractMapperTest<HarContent> {
 
     @Override
     public void testMapping() {
         HarContent content = map("{\"size\":123,\"compression\":45,\"mimeType\":\"mime/type\"," +
         "\"text\":\"my content\",\"encoding\":\"base64\",\"comment\":\"my comment\",\"_unknown\":\"unknown\"}", HarContent.class);
 
-        Assert.assertEquals(123L, (long) content.getSize());
-        Assert.assertEquals(45L, (long) content.getCompression());
-        Assert.assertEquals("mime/type", content.getMimeType());
-        Assert.assertEquals("my content", content.getText());
-        Assert.assertEquals("base64", content.getEncoding());
-        Assert.assertEquals("my comment", content.getComment());
+        assertEquals(123L, (long) content.getSize());
+        assertEquals(45L, (long) content.getCompression());
+        assertEquals("mime/type", content.getMimeType());
+        assertEquals("my content", content.getText());
+        assertEquals("base64", content.getEncoding());
+        assertEquals("my comment", content.getComment());
 
-        Assert.assertNotNull(content.getAdditional());
-        Assert.assertEquals("unknown", content.getAdditional().get("_unknown"));
+        assertNotNull(content.getAdditional());
+        assertEquals("unknown", content.getAdditional().get("_unknown"));
 
         content = map(UNKNOWN_PROPERTY, HarContent.class);
-        Assert.assertNotNull(content);
+        assertNotNull(content);
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarContent.class).verify();
     }
 

--- a/src/test/java/de/sstoehr/harreader/model/HarCookieTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCookieTest.java
@@ -1,12 +1,15 @@
 package de.sstoehr.harreader.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Date;
 
-public class HarCookieTest extends AbstractMapperTest<HarCookie> {
+import org.junit.jupiter.api.Test;
+
+class HarCookieTest extends AbstractMapperTest<HarCookie> {
 
     private final static Date EXPECTED_EXPIRES = new Date() {{
         setTime(1388577600000L);
@@ -17,25 +20,25 @@ public class HarCookieTest extends AbstractMapperTest<HarCookie> {
         HarCookie cookie = map("{\"name\":\"aName\",\"value\":\"aValue\",\"path\":\"/\",\"domain\":\"sstoehr.de\"," +
     "\"expires\":\"2014-01-01T12:00:00\",\"httpOnly\":\"true\",\"secure\":\"false\",\"comment\":\"my comment\",\"_unknown\":\"unknown\"}", HarCookie.class);
 
-        Assert.assertNotNull(cookie);
-        Assert.assertEquals("aName", cookie.getName());
-        Assert.assertEquals("aValue", cookie.getValue());
-        Assert.assertEquals("/", cookie.getPath());
-        Assert.assertEquals("sstoehr.de", cookie.getDomain());
-        Assert.assertEquals(EXPECTED_EXPIRES, cookie.getExpires());
-        Assert.assertEquals(true, cookie.getHttpOnly());
-        Assert.assertEquals(false, cookie.getSecure());
-        Assert.assertEquals("my comment", cookie.getComment());
+        assertNotNull(cookie);
+        assertEquals("aName", cookie.getName());
+        assertEquals("aValue", cookie.getValue());
+        assertEquals("/", cookie.getPath());
+        assertEquals("sstoehr.de", cookie.getDomain());
+        assertEquals(EXPECTED_EXPIRES, cookie.getExpires());
+        assertEquals(true, cookie.getHttpOnly());
+        assertEquals(false, cookie.getSecure());
+        assertEquals("my comment", cookie.getComment());
 
-        Assert.assertNotNull(cookie.getAdditional());
-        Assert.assertEquals("unknown", cookie.getAdditional().get("_unknown"));
+        assertNotNull(cookie.getAdditional());
+        assertEquals("unknown", cookie.getAdditional().get("_unknown"));
 
         cookie = map(UNKNOWN_PROPERTY, HarCookie.class);
-        Assert.assertNotNull(cookie);
+        assertNotNull(cookie);
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarCookie.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarCreatorBrowserTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCreatorBrowserTest.java
@@ -1,29 +1,32 @@
 package de.sstoehr.harreader.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class HarCreatorBrowserTest extends AbstractMapperTest<HarCreatorBrowser> {
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class HarCreatorBrowserTest extends AbstractMapperTest<HarCreatorBrowser> {
 
     @Override
     public void testMapping() {
         HarCreatorBrowser creatorBrowser = map("{\"name\":\"aName\",\"version\":\"aVersion\",\"comment\":\"my comment\",\"_unknown\":\"unknown\"}", HarCreatorBrowser.class);
 
-        Assert.assertNotNull(creatorBrowser);
-        Assert.assertEquals("aName", creatorBrowser.getName());
-        Assert.assertEquals("aVersion", creatorBrowser.getVersion());
-        Assert.assertEquals("my comment", creatorBrowser.getComment());
+        assertNotNull(creatorBrowser);
+        assertEquals("aName", creatorBrowser.getName());
+        assertEquals("aVersion", creatorBrowser.getVersion());
+        assertEquals("my comment", creatorBrowser.getComment());
 
-        Assert.assertNotNull(creatorBrowser.getAdditional());
-        Assert.assertEquals("unknown", creatorBrowser.getAdditional().get("_unknown"));
+        assertNotNull(creatorBrowser.getAdditional());
+        assertEquals("unknown", creatorBrowser.getAdditional().get("_unknown"));
 
         creatorBrowser = map(UNKNOWN_PROPERTY, HarCreatorBrowser.class);
-        Assert.assertNotNull(creatorBrowser);
+        assertNotNull(creatorBrowser);
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarCreatorBrowser.class).verify();
     }
 

--- a/src/test/java/de/sstoehr/harreader/model/HarEntryTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarEntryTest.java
@@ -1,10 +1,13 @@
 package de.sstoehr.harreader.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Date;
+
+import org.junit.jupiter.api.Test;
 
 public class HarEntryTest extends AbstractMapperTest<HarEntry> {
 
@@ -18,49 +21,49 @@ public class HarEntryTest extends AbstractMapperTest<HarEntry> {
         + "\"request\":{},\"response\":{},\"cache\":{},\"timings\":{},\"serverIPAddress\":\"1.2.3.4\",\"connection\":\"aConnection\","
         + "\"comment\":\"my comment\", \"_add\": \"additional info\"}", HarEntry.class);
 
-        Assert.assertNotNull(entry);
-        Assert.assertEquals("aPageref", entry.getPageref());
-        Assert.assertEquals(EXPECTED_STARTED, entry.getStartedDateTime());
-        Assert.assertEquals(12345, (int) entry.getTime());
-        Assert.assertNotNull(entry.getRequest());
-        Assert.assertNotNull(entry.getResponse());
-        Assert.assertNotNull(entry.getCache());
-        Assert.assertNotNull(entry.getTimings());
-        Assert.assertEquals("1.2.3.4", entry.getServerIPAddress());
-        Assert.assertEquals("aConnection", entry.getConnection());
-        Assert.assertEquals("my comment", entry.getComment());
-        Assert.assertEquals("additional info", entry.getAdditional().get("_add"));
+        assertNotNull(entry);
+        assertEquals("aPageref", entry.getPageref());
+        assertEquals(EXPECTED_STARTED, entry.getStartedDateTime());
+        assertEquals(12345, (int) entry.getTime());
+        assertNotNull(entry.getRequest());
+        assertNotNull(entry.getResponse());
+        assertNotNull(entry.getCache());
+        assertNotNull(entry.getTimings());
+        assertEquals("1.2.3.4", entry.getServerIPAddress());
+        assertEquals("aConnection", entry.getConnection());
+        assertEquals("my comment", entry.getComment());
+        assertEquals("additional info", entry.getAdditional().get("_add"));
 
         entry = map(UNKNOWN_PROPERTY, HarEntry.class);
-        Assert.assertNotNull(entry);
+        assertNotNull(entry);
     }
 
     @Test
     public void testRequestNull() {
         HarEntry entry = new HarEntry();
         entry.setRequest(null);
-        Assert.assertNotNull(entry.getRequest());
+        assertNotNull(entry.getRequest());
     }
 
     @Test
     public void testResponseNull() {
         HarEntry entry = new HarEntry();
         entry.setResponse(null);
-        Assert.assertNotNull(entry.getResponse());
+        assertNotNull(entry.getResponse());
     }
 
     @Test
     public void testCacheNull() {
         HarEntry entry = new HarEntry();
         entry.setCache(null);
-        Assert.assertNotNull(entry.getCache());
+        assertNotNull(entry.getCache());
     }
 
     @Test
     public void testTimingsNull() {
         HarEntry entry = new HarEntry();
         entry.setTimings(null);
-        Assert.assertNotNull(entry.getTimings());
+        assertNotNull(entry.getTimings());
     }
 
     @Test

--- a/src/test/java/de/sstoehr/harreader/model/HarHeaderTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarHeaderTest.java
@@ -1,29 +1,32 @@
 package de.sstoehr.harreader.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class HarHeaderTest extends AbstractMapperTest<HarHeader> {
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class HarHeaderTest extends AbstractMapperTest<HarHeader> {
 
     @Override
     public void testMapping() {
         HarHeader header = map("{\"name\":\"aName\",\"value\":\"aValue\",\"comment\":\"my comment\",\"_unknown\":\"unknown\"}", HarHeader.class);
 
-        Assert.assertNotNull(header);
-        Assert.assertEquals("aName", header.getName());
-        Assert.assertEquals("aValue", header.getValue());
-        Assert.assertEquals("my comment", header.getComment());
+        assertNotNull(header);
+        assertEquals("aName", header.getName());
+        assertEquals("aValue", header.getValue());
+        assertEquals("my comment", header.getComment());
 
-        Assert.assertNotNull(header.getAdditional());
-        Assert.assertEquals("unknown", header.getAdditional().get("_unknown"));
+        assertNotNull(header.getAdditional());
+        assertEquals("unknown", header.getAdditional().get("_unknown"));
 
         header = map(UNKNOWN_PROPERTY, HarHeader.class);
-        Assert.assertNotNull(header);
+        assertNotNull(header);
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarHeader.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
@@ -1,88 +1,91 @@
 package de.sstoehr.harreader.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class HarLogTest extends AbstractMapperTest<HarLog> {
+import org.junit.jupiter.api.Test;
+
+class HarLogTest extends AbstractMapperTest<HarLog> {
 
     private static final String EXPECTED_DEFAULT_VERSION = "1.1";
     private static final List<HarPage> EXPECTED_PAGES_LIST = new ArrayList<>();
     private static final List<HarEntry> EXPECTED_ENTRIES_LIST = new ArrayList<>();
 
     @Test
-    public void testVersion() {
+    void testVersion() {
         HarLog log = new HarLog();
-        Assert.assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
+        assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
 
         log.setVersion("1.2");
-        Assert.assertEquals("1.2", log.getVersion());
+        assertEquals("1.2", log.getVersion());
 
         log.setVersion(null);
-        Assert.assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
+        assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
 
         log.setVersion("");
-        Assert.assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
+        assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
 
         log.setVersion("  ");
-        Assert.assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
+        assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
     }
 
     @Test
-    public void testPages() {
+    void testPages() {
         HarLog log = new HarLog();
-        Assert.assertEquals(EXPECTED_PAGES_LIST, log.getPages());
+        assertEquals(EXPECTED_PAGES_LIST, log.getPages());
 
         log.setPages(null);
-        Assert.assertEquals(EXPECTED_PAGES_LIST, log.getPages());
+        assertEquals(EXPECTED_PAGES_LIST, log.getPages());
     }
 
     @Test
-    public void testEntries() {
+    void testEntries() {
         HarLog log = new HarLog();
-        Assert.assertEquals(EXPECTED_ENTRIES_LIST, log.getEntries());
+        assertEquals(EXPECTED_ENTRIES_LIST, log.getEntries());
 
         log.setEntries(null);
-        Assert.assertEquals(EXPECTED_ENTRIES_LIST, log.getEntries());
+        assertEquals(EXPECTED_ENTRIES_LIST, log.getEntries());
     }
 
     @Test
-    public void testCreatorNull() {
+    void testCreatorNull() {
         HarLog log = new HarLog();
         log.setCreator(null);
-        Assert.assertNotNull(log.getCreator());
+        assertNotNull(log.getCreator());
     }
 
     @Test
-    public void testBrowserNull() {
+    void testBrowserNull() {
         HarLog log = new HarLog();
         log.setBrowser(null);
-        Assert.assertNotNull(log.getBrowser());
+        assertNotNull(log.getBrowser());
     }
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         HarLog log = map("{\"creator\": {}, \"browser\": {}, \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarLog.class);
 
-        Assert.assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
-        Assert.assertNotNull(log.getCreator());
-        Assert.assertNotNull(log.getBrowser());
-        Assert.assertEquals(EXPECTED_PAGES_LIST, log.getPages());
-        Assert.assertEquals(EXPECTED_ENTRIES_LIST, log.getEntries());
-        Assert.assertEquals("My comment", log.getComment());
+        assertEquals(EXPECTED_DEFAULT_VERSION, log.getVersion());
+        assertNotNull(log.getCreator());
+        assertNotNull(log.getBrowser());
+        assertEquals(EXPECTED_PAGES_LIST, log.getPages());
+        assertEquals(EXPECTED_ENTRIES_LIST, log.getEntries());
+        assertEquals("My comment", log.getComment());
 
-        Assert.assertNotNull(log.getAdditional());
-        Assert.assertEquals("unknown", log.getAdditional().get("_unknown"));
+        assertNotNull(log.getAdditional());
+        assertEquals("unknown", log.getAdditional().get("_unknown"));
 
         log = map(UNKNOWN_PROPERTY, HarLog.class);
-        Assert.assertNotNull(log);
+        assertNotNull(log);
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarLog.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarPageTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPageTest.java
@@ -1,43 +1,46 @@
 package de.sstoehr.harreader.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Date;
 
-public class HarPageTest extends AbstractMapperTest<HarPage> {
+import org.junit.jupiter.api.Test;
+
+class HarPageTest extends AbstractMapperTest<HarPage> {
 
     private final static Date EXPECTED_STARTED = new Date() {{
         setTime(1388577600000L);
     }};
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         HarPage page = map("{\"startedDateTime\":\"2014-01-01T12:00:00\",\"id\":\"anId\","
         + "\"title\":\"aTitle\",\"pageTimings\":{},\"comment\":\"my comment\", \"_add\": \"additional info\"}", HarPage.class);
 
-        Assert.assertNotNull(page);
-        Assert.assertEquals(EXPECTED_STARTED, page.getStartedDateTime());
-        Assert.assertEquals("anId", page.getId());
-        Assert.assertEquals("aTitle", page.getTitle());
-        Assert.assertNotNull(page.getPageTimings());
-        Assert.assertEquals("my comment", page.getComment());
-        Assert.assertEquals("additional info", page.getAdditional().get("_add"));
+        assertNotNull(page);
+        assertEquals(EXPECTED_STARTED, page.getStartedDateTime());
+        assertEquals("anId", page.getId());
+        assertEquals("aTitle", page.getTitle());
+        assertNotNull(page.getPageTimings());
+        assertEquals("my comment", page.getComment());
+        assertEquals("additional info", page.getAdditional().get("_add"));
 
         page = map(UNKNOWN_PROPERTY, HarPage.class);
-        Assert.assertNotNull(page);
+        assertNotNull(page);
     }
 
     @Test
-    public void testPageTimingsNull() {
+    void testPageTimingsNull() {
         HarPage page = new HarPage();
         page.setPageTimings(null);
-        Assert.assertNotNull(page.getPageTimings());
+        assertNotNull(page.getPageTimings());
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarPage.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarPageTimingTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPageTimingTest.java
@@ -1,54 +1,57 @@
 package de.sstoehr.harreader.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
 
-public class HarPageTimingTest extends AbstractMapperTest<HarPageTiming> {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class HarPageTimingTest extends AbstractMapperTest<HarPageTiming> {
 
     private static final Integer EXPECTED_DEFAULT_DURATION = -1;
 
     @Test
-    public void testOnContentLoad() {
+    void testOnContentLoad() {
         HarPageTiming pageTiming = new HarPageTiming();
-        Assert.assertEquals(EXPECTED_DEFAULT_DURATION, pageTiming.getOnContentLoad());
+        assertEquals(EXPECTED_DEFAULT_DURATION, pageTiming.getOnContentLoad());
 
         pageTiming.setOnContentLoad(1234);
-        Assert.assertEquals(1234, (int) pageTiming.getOnContentLoad());
+        assertEquals(1234, (int) pageTiming.getOnContentLoad());
 
         pageTiming.setOnContentLoad(null);
-        Assert.assertEquals(EXPECTED_DEFAULT_DURATION, pageTiming.getOnContentLoad());
+        assertEquals(EXPECTED_DEFAULT_DURATION, pageTiming.getOnContentLoad());
     }
 
     @Test
-    public void testOnLoad() {
+    void testOnLoad() {
         HarPageTiming pageTiming = new HarPageTiming();
-        Assert.assertEquals(EXPECTED_DEFAULT_DURATION, pageTiming.getOnLoad());
+        assertEquals(EXPECTED_DEFAULT_DURATION, pageTiming.getOnLoad());
 
         pageTiming.setOnLoad(1234);
-        Assert.assertEquals(1234, (int) pageTiming.getOnLoad());
+        assertEquals(1234, (int) pageTiming.getOnLoad());
 
         pageTiming.setOnLoad(null);
-        Assert.assertEquals(EXPECTED_DEFAULT_DURATION, pageTiming.getOnLoad());
+        assertEquals(EXPECTED_DEFAULT_DURATION, pageTiming.getOnLoad());
     }
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         HarPageTiming pageTiming = map("{\"onContentLoad\": 1234, \"onLoad\": 5678, \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarPageTiming.class);
 
-        Assert.assertEquals(1234, (int) pageTiming.getOnContentLoad());
-        Assert.assertEquals(5678, (int) pageTiming.getOnLoad());
-        Assert.assertEquals("My comment", pageTiming.getComment());
+        assertEquals(1234, (int) pageTiming.getOnContentLoad());
+        assertEquals(5678, (int) pageTiming.getOnLoad());
+        assertEquals("My comment", pageTiming.getComment());
 
-        Assert.assertNotNull(pageTiming.getAdditional());
-        Assert.assertEquals("unknown", pageTiming.getAdditional().get("_unknown"));
+        assertNotNull(pageTiming.getAdditional());
+        assertEquals("unknown", pageTiming.getAdditional().get("_unknown"));
 
         pageTiming = map(UNKNOWN_PROPERTY, HarPageTiming.class);
-        Assert.assertNotNull(pageTiming);
+        assertNotNull(pageTiming);
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarPageTiming.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarPostDataParamTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPostDataParamTest.java
@@ -1,30 +1,33 @@
 package de.sstoehr.harreader.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class HarPostDataParamTest extends AbstractMapperTest<HarPostDataParam> {
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class HarPostDataParamTest extends AbstractMapperTest<HarPostDataParam> {
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         HarPostDataParam postDataParam = map("{\"name\": \"aName\", \"value\": \"aValue\", \"fileName\": \"aFilename\", \"contentType\": \"aContentType\", \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarPostDataParam.class);
 
-        Assert.assertEquals("aName", postDataParam.getName());
-        Assert.assertEquals("aValue", postDataParam.getValue());
-        Assert.assertEquals("aFilename", postDataParam.getFileName());
-        Assert.assertEquals("aContentType", postDataParam.getContentType());
-        Assert.assertEquals("My comment", postDataParam.getComment());
+        assertEquals("aName", postDataParam.getName());
+        assertEquals("aValue", postDataParam.getValue());
+        assertEquals("aFilename", postDataParam.getFileName());
+        assertEquals("aContentType", postDataParam.getContentType());
+        assertEquals("My comment", postDataParam.getComment());
 
-        Assert.assertNotNull(postDataParam.getAdditional());
-        Assert.assertEquals("unknown", postDataParam.getAdditional().get("_unknown"));
+        assertNotNull(postDataParam.getAdditional());
+        assertEquals("unknown", postDataParam.getAdditional().get("_unknown"));
 
         postDataParam = map(UNKNOWN_PROPERTY, HarPostDataParam.class);
-        Assert.assertNotNull(postDataParam);
+        assertNotNull(postDataParam);
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarPostDataParam.class).verify();
     }
 

--- a/src/test/java/de/sstoehr/harreader/model/HarPostDataTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPostDataTest.java
@@ -1,11 +1,14 @@
 package de.sstoehr.harreader.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 public class HarPostDataTest extends AbstractMapperTest<HarPostData> {
 
@@ -15,23 +18,23 @@ public class HarPostDataTest extends AbstractMapperTest<HarPostData> {
     public void testMapping() {
         HarPostData postData = map("{\"mimeType\": \"aMimeType\", \"params\": [], \"text\":\"aText\", \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarPostData.class);
 
-        Assert.assertEquals("aMimeType", postData.getMimeType());
-        Assert.assertEquals(EXPECTED_LIST, postData.getParams());
-        Assert.assertEquals("aText", postData.getText());
-        Assert.assertEquals("My comment", postData.getComment());
+        assertEquals("aMimeType", postData.getMimeType());
+        assertEquals(EXPECTED_LIST, postData.getParams());
+        assertEquals("aText", postData.getText());
+        assertEquals("My comment", postData.getComment());
 
-        Assert.assertNotNull(postData.getAdditional());
-        Assert.assertEquals("unknown", postData.getAdditional().get("_unknown"));
+        assertNotNull(postData.getAdditional());
+        assertEquals("unknown", postData.getAdditional().get("_unknown"));
 
         postData = map(UNKNOWN_PROPERTY, HarPostData.class);
-        Assert.assertNotNull(postData);
+        assertNotNull(postData);
     }
 
     @Test
     public void testParams() {
         HarPostData postData = new HarPostData();
         postData.setParams(null);
-        Assert.assertNotNull(postData.getParams());
+        assertNotNull(postData.getParams());
     }
 
     @Test

--- a/src/test/java/de/sstoehr/harreader/model/HarQueryParamTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarQueryParamTest.java
@@ -1,25 +1,28 @@
 package de.sstoehr.harreader.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class HarQueryParamTest extends AbstractMapperTest<HarQueryParam> {
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class HarQueryParamTest extends AbstractMapperTest<HarQueryParam> {
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         HarQueryParam queryParam = map("{\"name\": \"aName\", \"value\":\"aValue\", \"comment\": \"My comment\",\"_unknown\":\"unknown\"}", HarQueryParam.class);
 
-        Assert.assertEquals("aName", queryParam.getName());
-        Assert.assertEquals("aValue", queryParam.getValue());
-        Assert.assertEquals("My comment", queryParam.getComment());
+        assertEquals("aName", queryParam.getName());
+        assertEquals("aValue", queryParam.getValue());
+        assertEquals("My comment", queryParam.getComment());
 
-        Assert.assertNotNull(queryParam.getAdditional());
-        Assert.assertEquals("unknown", queryParam.getAdditional().get("_unknown"));
+        assertNotNull(queryParam.getAdditional());
+        assertEquals("unknown", queryParam.getAdditional().get("_unknown"));
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarQueryParam.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
@@ -1,77 +1,80 @@
 package de.sstoehr.harreader.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class HarRequestTest extends AbstractMapperTest<HarRequest> {
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class HarRequestTest extends AbstractMapperTest<HarRequest> {
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         HarRequest request = map("{\"method\": \"GET\",\"url\": "
          + "\"http://www.sebastianstoehr.de/\",\"httpVersion\": "
          + "\"HTTP/1.1\",\"cookies\": [],\"headers\": [],\"queryString\": [],"
          + "\"headersSize\": 676,\"bodySize\": -1, \"postData\": {}, \"comment\":\"my comment\","
          + "\"_add\": \"additional info\"}", HarRequest.class);
 
-        Assert.assertNotNull(request);
-        Assert.assertEquals(HttpMethod.GET, request.getMethod());
-        Assert.assertEquals("http://www.sebastianstoehr.de/", request.getUrl());
-        Assert.assertEquals("HTTP/1.1", request.getHttpVersion());
-        Assert.assertNotNull(request.getCookies());
-        Assert.assertNotNull(request.getHeaders());
-        Assert.assertNotNull(request.getQueryString());
-        Assert.assertNotNull(request.getPostData());
-        Assert.assertEquals(676L, (long) request.getHeadersSize());
-        Assert.assertEquals(-1L, (long) request.getBodySize());
-        Assert.assertEquals("my comment", request.getComment());
-        Assert.assertEquals("additional info", request.getAdditional().get("_add"));
+        assertNotNull(request);
+        assertEquals(HttpMethod.GET, request.getMethod());
+        assertEquals("http://www.sebastianstoehr.de/", request.getUrl());
+        assertEquals("HTTP/1.1", request.getHttpVersion());
+        assertNotNull(request.getCookies());
+        assertNotNull(request.getHeaders());
+        assertNotNull(request.getQueryString());
+        assertNotNull(request.getPostData());
+        assertEquals(676L, (long) request.getHeadersSize());
+        assertEquals(-1L, (long) request.getBodySize());
+        assertEquals("my comment", request.getComment());
+        assertEquals("additional info", request.getAdditional().get("_add"));
     }
 
     @Test
-    public void testCookies() {
+    void testCookies() {
         HarRequest request = new HarRequest();
         request.setCookies(null);
-        Assert.assertNotNull(request.getCookies());
+        assertNotNull(request.getCookies());
     }
 
     @Test
-    public void testHeaders() {
+    void testHeaders() {
         HarRequest request = new HarRequest();
         request.setHeaders(null);
-        Assert.assertNotNull(request.getHeaders());
+        assertNotNull(request.getHeaders());
     }
 
     @Test
-    public void testQueryString() {
+    void testQueryString() {
         HarRequest request = new HarRequest();
         request.setQueryString(null);
-        Assert.assertNotNull(request.getQueryString());
+        assertNotNull(request.getQueryString());
     }
 
     @Test
-    public void testPostData() {
+    void testPostData() {
         HarRequest request = new HarRequest();
         request.setPostData(null);
-        Assert.assertNotNull(request.getPostData());
+        assertNotNull(request.getPostData());
     }
 
     @Test
-    public void testHeadersSize() {
+    void testHeadersSize() {
         HarRequest request = new HarRequest();
         request.setHeadersSize(null);
-        Assert.assertEquals(-1L, (long) request.getHeadersSize());
+        assertEquals(-1L, (long) request.getHeadersSize());
     }
 
     @Test
-    public void testBodySize() {
+    void testBodySize() {
         HarRequest request = new HarRequest();
         request.setBodySize(null);
-        Assert.assertEquals(-1L, (long) request.getBodySize());
+        assertEquals(-1L, (long) request.getBodySize());
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarRequest.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
@@ -1,74 +1,77 @@
 package de.sstoehr.harreader.model;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
 
-public class HarResponseTest extends AbstractMapperTest<HarResponse> {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class HarResponseTest extends AbstractMapperTest<HarResponse> {
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         HarResponse response = map("{\"status\": 200,\"statusText\": \"OK\",\"httpVersion\": \"HTTP/1.1\","
         + "\"cookies\": [],\"headers\": [],\"content\": {},\"redirectURL\": \"redirectUrl\",\"headersSize\": 318,"
         + "\"bodySize\": 16997,\"comment\": \"My comment\", \"_add\": \"additional info\"}", HarResponse.class);
 
-        Assert.assertNotNull(response);
-        Assert.assertEquals(200, response.getStatus());
-        Assert.assertEquals("OK", response.getStatusText());
-        Assert.assertEquals("HTTP/1.1", response.getHttpVersion());
-        Assert.assertNotNull(response.getCookies());
-        Assert.assertNotNull(response.getHeaders());
-        Assert.assertNotNull(response.getContent());
-        Assert.assertEquals("redirectUrl", response.getRedirectURL());
-        Assert.assertEquals(318L, (long) response.getHeadersSize());
-        Assert.assertEquals(16997L, (long) response.getBodySize());
-        Assert.assertEquals("My comment", response.getComment());
-        Assert.assertEquals("additional info", response.getAdditional().get("_add"));
+        assertNotNull(response);
+        assertEquals(200, response.getStatus());
+        assertEquals("OK", response.getStatusText());
+        assertEquals("HTTP/1.1", response.getHttpVersion());
+        assertNotNull(response.getCookies());
+        assertNotNull(response.getHeaders());
+        assertNotNull(response.getContent());
+        assertEquals("redirectUrl", response.getRedirectURL());
+        assertEquals(318L, (long) response.getHeadersSize());
+        assertEquals(16997L, (long) response.getBodySize());
+        assertEquals("My comment", response.getComment());
+        assertEquals("additional info", response.getAdditional().get("_add"));
     }
 
     @Test
-    public void testStatus() {
+    void testStatus() {
         HarResponse response = new HarResponse();
-        Assert.assertEquals(0, response.getStatus());
+        assertEquals(0, response.getStatus());
     }
 
     @Test
-    public void testCookies() {
+    void testCookies() {
         HarResponse response = new HarResponse();
         response.setCookies(null);
-        Assert.assertNotNull(response.getCookies());
+        assertNotNull(response.getCookies());
     }
 
     @Test
-    public void testHeaders() {
+    void testHeaders() {
         HarResponse response = new HarResponse();
         response.setHeaders(null);
-        Assert.assertNotNull(response.getHeaders());
+        assertNotNull(response.getHeaders());
     }
 
     @Test
-    public void testContent() {
+    void testContent() {
         HarResponse response = new HarResponse();
         response.setContent(null);
-        Assert.assertNotNull(response.getContent());
+        assertNotNull(response.getContent());
     }
     
     @Test
-    public void testHeadersSize() {
+    void testHeadersSize() {
         HarResponse response = new HarResponse();
         response.setHeadersSize(null);
-        Assert.assertEquals(-1L, (long) response.getHeadersSize());
+        assertEquals(-1L, (long) response.getHeadersSize());
     }
 
     @Test
-    public void testBodySize() {
+    void testBodySize() {
         HarResponse response = new HarResponse();
         response.setBodySize(null);
-        Assert.assertEquals(-1L, (long) response.getBodySize());
+        assertEquals(-1L, (long) response.getBodySize());
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarResponse.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarTest.java
@@ -1,29 +1,31 @@
 package de.sstoehr.harreader.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class HarTest extends AbstractMapperTest<Har>{
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class HarTest extends AbstractMapperTest<Har>{
 
     @Test
-    public void testLogNull() {
+    void testLogNull() {
         Har har = new Har();
         har.setLog(null);
-        Assert.assertNotNull(har.getLog());
+        assertNotNull(har.getLog());
     }
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         Har har = map("{\"log\": {}}", Har.class);
-        Assert.assertNotNull(har.getLog());
+        assertNotNull(har.getLog());
 
         har = map(UNKNOWN_PROPERTY, Har.class);
-        Assert.assertNotNull(har);
+        assertNotNull(har);
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(Har.class).verify();
     }
 

--- a/src/test/java/de/sstoehr/harreader/model/HarTimingTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarTimingTest.java
@@ -1,60 +1,63 @@
 package de.sstoehr.harreader.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class HarTimingTest extends AbstractMapperTest<HarTiming> {
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class HarTimingTest extends AbstractMapperTest<HarTiming> {
 
     @Override
-    public void testMapping() {
+    void testMapping() {
         HarTiming timing = map("{\"blocked\": 3804,\"dns\": 23,\"connect\": 5,\"send\": 9,\"wait\": 5209,"
         + "\"receive\": 79, \"ssl\": 123, \"comment\": \"my comment\",\"_unknown\":\"unknown\"}", HarTiming.class);
 
-        Assert.assertNotNull(timing);
-        Assert.assertEquals(3804, (int) timing.getBlocked());
-        Assert.assertEquals(23, (int) timing.getDns());
-        Assert.assertEquals(5, (int) timing.getConnect());
-        Assert.assertEquals(9, (int) timing.getSend());
-        Assert.assertEquals(5209, (int) timing.getWait());
-        Assert.assertEquals(79, (int) timing.getReceive());
-        Assert.assertEquals(123, (int) timing.getSsl());
-        Assert.assertEquals("my comment", timing.getComment());
+        assertNotNull(timing);
+        assertEquals(3804, (int) timing.getBlocked());
+        assertEquals(23, (int) timing.getDns());
+        assertEquals(5, (int) timing.getConnect());
+        assertEquals(9, (int) timing.getSend());
+        assertEquals(5209, (int) timing.getWait());
+        assertEquals(79, (int) timing.getReceive());
+        assertEquals(123, (int) timing.getSsl());
+        assertEquals("my comment", timing.getComment());
 
-        Assert.assertNotNull(timing.getAdditional());
-        Assert.assertEquals("unknown", timing.getAdditional().get("_unknown"));
+        assertNotNull(timing.getAdditional());
+        assertEquals("unknown", timing.getAdditional().get("_unknown"));
     }
 
     @Test
-    public void testBlocked() {
+    void testBlocked() {
         HarTiming timing = new HarTiming();
         timing.setBlocked(null);
-        Assert.assertEquals(-1, (int) timing.getBlocked());
+        assertEquals(-1, (int) timing.getBlocked());
     }
 
     @Test
-    public void testDns() {
+    void testDns() {
         HarTiming timing = new HarTiming();
         timing.setDns(null);
-        Assert.assertEquals(-1, (int) timing.getDns());
+        assertEquals(-1, (int) timing.getDns());
     }
 
     @Test
-    public void testConnect() {
+    void testConnect() {
         HarTiming timing = new HarTiming();
         timing.setConnect(null);
-        Assert.assertEquals(-1, (int) timing.getConnect());
+        assertEquals(-1, (int) timing.getConnect());
     }
 
     @Test
-    public void testSsl() {
+    void testSsl() {
         HarTiming timing = new HarTiming();
         timing.setSsl(null);
-        Assert.assertEquals(-1, (int) timing.getSsl());
+        assertEquals(-1, (int) timing.getSsl());
     }
 
     @Test
-    public void equalsContract() {
+    void equalsContract() {
         EqualsVerifier.simple().forClass(HarTiming.class).verify();
     }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HttpStatusTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HttpStatusTest.java
@@ -1,27 +1,28 @@
 package de.sstoehr.harreader.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class HttpStatusTest {
+import org.junit.jupiter.api.Test;
+
+class HttpStatusTest {
 
     @Test
-    public void testByCode() {
+    void testByCode() {
         for (HttpStatus status : HttpStatus.values()) {
-            Assert.assertEquals(status, HttpStatus.byCode(status.getCode()));
+            assertEquals(status, HttpStatus.byCode(status.getCode()));
         }
     }
 
     @Test
-    public void test302() {
-        Assert.assertEquals(HttpStatus.FOUND, HttpStatus.byCode(302));
+    void test302() {
+        assertEquals(HttpStatus.FOUND, HttpStatus.byCode(302));
     }
 
     @Test
-    public void testInvalidCode() {
-        Assert.assertEquals(HttpStatus.UNKNOWN_HTTP_STATUS, HttpStatus.byCode(0));
-        Assert.assertEquals(HttpStatus.UNKNOWN_HTTP_STATUS, HttpStatus.byCode(1000));
-        Assert.assertEquals(HttpStatus.UNKNOWN_HTTP_STATUS, HttpStatus.byCode(-999));
+    void testInvalidCode() {
+        assertEquals(HttpStatus.UNKNOWN_HTTP_STATUS, HttpStatus.byCode(0));
+        assertEquals(HttpStatus.UNKNOWN_HTTP_STATUS, HttpStatus.byCode(1000));
+        assertEquals(HttpStatus.UNKNOWN_HTTP_STATUS, HttpStatus.byCode(-999));
     }
 
 }


### PR DESCRIPTION
- Now using JUnit 5.
- Now targeting Java 8 (to support lambdas).
- Updated Jackson dependencies to address vulnerabilities.
- .gitignore now includes some Eclipse related entries.

https://mvnrepository.com/artifact/de.sstoehr/har-reader/2.2.1
![image](https://github.com/sdstoehr/har-reader/assets/7570458/0611e951-a046-4ffe-baf5-e665cfd33b87)
CVE-2022-42004
CVE-2022-42003