### PR TITLE
Added support for all HttpMethod and HttpStatus

### DIFF
--- a/src/main/java/de/sstoehr/harreader/model/HarRequest.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ public class HarRequest {
     protected static final Long DEFAULT_SIZE = -1L;
 
     private HttpMethod method;
+    private String rawMethod;
     private String url;
     private String httpVersion;
     private List<HarCookie> cookies;
@@ -42,6 +44,21 @@ public class HarRequest {
 
     public void setMethod(HttpMethod method) {
         this.method = method;
+        this.rawMethod = method.name();
+    }
+
+    /**
+     * @return Request method, null if not present.
+     */
+    @JsonProperty("method")
+    public String getRawMethod() {
+        return rawMethod;
+    }
+
+    @JsonProperty("method")
+    public void setRawMethod(String rawMethod) {
+        this.method = HttpMethod.fromString(rawMethod);
+        this.rawMethod = rawMethod;
     }
 
     /**
@@ -182,6 +199,7 @@ public class HarRequest {
         if (!(o instanceof HarRequest)) return false;
         HarRequest that = (HarRequest) o;
         return method == that.method &&
+                Objects.equals(rawMethod, that.rawMethod) &&
                 Objects.equals(url, that.url) &&
                 Objects.equals(httpVersion, that.httpVersion) &&
                 Objects.equals(cookies, that.cookies) &&
@@ -196,7 +214,7 @@ public class HarRequest {
 
     @Override
     public int hashCode() {
-        return Objects.hash(method, url, httpVersion, cookies, headers, queryString, postData, headersSize,
+        return Objects.hash(method, rawMethod, url, httpVersion, cookies, headers, queryString, postData, headersSize,
                 bodySize, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarResponse.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ public class HarResponse {
     protected static final Long DEFAULT_SIZE = -1L;
 
     private HttpStatus status;
+    private int rawStatus = HttpStatus.UNKNOWN_HTTP_STATUS.getCode();
     private String statusText;
     private String httpVersion;
     private List<HarCookie> cookies;
@@ -34,7 +36,7 @@ public class HarResponse {
     private final Map<String, Object> additional = new HashMap<>();
 
     /**
-     * @return Response status, null if not present.
+     * @return Response status, 0 if not present or unknown.
      */
     public int getStatus() {
         if (status == null) {
@@ -45,6 +47,21 @@ public class HarResponse {
 
     public void setStatus(int status) {
         this.status = HttpStatus.byCode(status);
+        this.rawStatus = status;
+    }
+
+    /**
+     * @return Response status, 0 if not present
+     */
+    @JsonProperty("status")
+    public int getRawStatus() {
+        return rawStatus;
+    }
+
+    @JsonProperty("status")
+    public void setRawStatus(int rawStatus) {
+        this.status = HttpStatus.byCode(rawStatus);
+        this.rawStatus = rawStatus;
     }
 
     /**
@@ -183,6 +200,7 @@ public class HarResponse {
         if (!(o instanceof HarResponse)) return false;
         HarResponse that = (HarResponse) o;
         return status == that.status &&
+                rawStatus == that.rawStatus &&
                 Objects.equals(statusText, that.statusText) &&
                 Objects.equals(httpVersion, that.httpVersion) &&
                 Objects.equals(cookies, that.cookies) &&
@@ -197,7 +215,7 @@ public class HarResponse {
 
     @Override
     public int hashCode() {
-        return Objects.hash(status, statusText, httpVersion, cookies, headers, content, redirectURL, headersSize,
+        return Objects.hash(status, rawStatus, statusText, httpVersion, cookies, headers, content, redirectURL, headersSize,
                 bodySize, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HttpMethod.java
+++ b/src/main/java/de/sstoehr/harreader/model/HttpMethod.java
@@ -1,5 +1,13 @@
 package de.sstoehr.harreader.model;
 
 public enum HttpMethod {
-    GET, POST, PUT, HEAD, PROPFIND, OPTIONS, REPORT, DELETE, CONNECT, TRACE, CCM_POST, PATCH;
+    GET, POST, PUT, HEAD, PROPFIND, OPTIONS, REPORT, DELETE, CONNECT, TRACE, CCM_POST, PATCH, UNKNOWN;
+
+    public static HttpMethod fromString(String method) {
+        try {
+            return HttpMethod.valueOf(method.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return HttpMethod.UNKNOWN;
+        }
+    }
 }

--- a/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
@@ -19,6 +19,7 @@ class HarRequestTest extends AbstractMapperTest<HarRequest> {
 
         assertNotNull(request);
         assertEquals(HttpMethod.GET, request.getMethod());
+        assertEquals("GET", request.getRawMethod());
         assertEquals("http://www.sebastianstoehr.de/", request.getUrl());
         assertEquals("HTTP/1.1", request.getHttpVersion());
         assertNotNull(request.getCookies());
@@ -71,6 +72,14 @@ class HarRequestTest extends AbstractMapperTest<HarRequest> {
         HarRequest request = new HarRequest();
         request.setBodySize(null);
         assertEquals(-1L, (long) request.getBodySize());
+    }
+
+    @Test
+    void testUnknownMethod() {
+        HarRequest request = new HarRequest();
+        request.setRawMethod("NOT_PART_OF_ENUM");
+        assertEquals("NOT_PART_OF_ENUM", request.getRawMethod());
+        assertEquals(HttpMethod.UNKNOWN, request.getMethod());
     }
 
     @Test

--- a/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
@@ -77,6 +77,14 @@ class HarRequestTest extends AbstractMapperTest<HarRequest> {
     @Test
     void testUnknownMethod() {
         HarRequest request = new HarRequest();
+        request.setMethod(HttpMethod.POST);
+        assertEquals("POST", request.getRawMethod());
+        assertEquals(HttpMethod.POST, request.getMethod());
+    }
+
+    @Test
+    void testUnknownMethodRaw() {
+        HarRequest request = new HarRequest();
         request.setRawMethod("NOT_PART_OF_ENUM");
         assertEquals("NOT_PART_OF_ENUM", request.getRawMethod());
         assertEquals(HttpMethod.UNKNOWN, request.getMethod());

--- a/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
@@ -39,6 +39,15 @@ class HarResponseTest extends AbstractMapperTest<HarResponse> {
     @Test
     void testUnknownStatus() {
         HarResponse response = new HarResponse();
+        response.setStatus(600);
+
+        assertEquals(0, response.getStatus()); // old behaviour, falling back to UNKNOWN_STATUS_CODE
+        assertEquals(600, response.getRawStatus());
+    }
+
+    @Test
+    void testUnknownStatusRaw() {
+        HarResponse response = new HarResponse();
         response.setRawStatus(600);
 
         assertEquals(0, response.getStatus()); // old behaviour, falling back to UNKNOWN_STATUS_CODE

--- a/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
@@ -33,6 +33,16 @@ class HarResponseTest extends AbstractMapperTest<HarResponse> {
     void testStatus() {
         HarResponse response = new HarResponse();
         assertEquals(0, response.getStatus());
+        assertEquals(0, response.getRawStatus());
+    }
+
+    @Test
+    void testUnknownStatus() {
+        HarResponse response = new HarResponse();
+        response.setRawStatus(600);
+
+        assertEquals(0, response.getStatus()); // old behaviour, falling back to UNKNOWN_STATUS_CODE
+        assertEquals(600, response.getRawStatus());
     }
 
     @Test


### PR DESCRIPTION
Fixes #168

-----

Added backward compatible support for `HttpMethod`s and `HttpStatus`es, which are not included in the respective enums. The raw values can be accessed through `HttpRequest.getRawMethod()` or `HttpResponse.getRawStatus()`.
The behaviour of the old fields are unchanged (which might lead to the situation, that `getStatus() = 0` (unknown status code) but `getRawStatus() != 0` 

The only change in behaviour is, that previously an unsupported HttpMethod led to an exception during serialization, whereas it now serializes the method to `HttpMethod.UNKNOWN` with the real underlying value in the rawMethod field.