### PR TITLE
Fix fields and getters name collision

### DIFF
--- a/src/main/java/de/sstoehr/harreader/model/HarRequest.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarRequest.java
@@ -22,8 +22,8 @@ public class HarRequest {
 
     protected static final Long DEFAULT_SIZE = -1L;
 
-    private HttpMethod method;
-    private String rawMethod;
+    private HttpMethod parsedMethod;
+    private String method;
     private String url;
     private String httpVersion;
     private List<HarCookie> cookies;
@@ -39,12 +39,12 @@ public class HarRequest {
      * @return Request method, null if not present.
      */
     public HttpMethod getMethod() {
-        return method;
+        return parsedMethod;
     }
 
     public void setMethod(HttpMethod method) {
-        this.method = method;
-        this.rawMethod = method.name();
+        this.parsedMethod = method;
+        this.method = method.name();
     }
 
     /**
@@ -52,13 +52,13 @@ public class HarRequest {
      */
     @JsonProperty("method")
     public String getRawMethod() {
-        return rawMethod;
+        return method;
     }
 
     @JsonProperty("method")
     public void setRawMethod(String rawMethod) {
-        this.method = HttpMethod.fromString(rawMethod);
-        this.rawMethod = rawMethod;
+        this.parsedMethod = HttpMethod.fromString(rawMethod);
+        this.method = rawMethod;
     }
 
     /**
@@ -198,8 +198,8 @@ public class HarRequest {
         if (this == o) return true;
         if (!(o instanceof HarRequest)) return false;
         HarRequest that = (HarRequest) o;
-        return method == that.method &&
-                Objects.equals(rawMethod, that.rawMethod) &&
+        return parsedMethod == that.parsedMethod &&
+                Objects.equals(method, that.method) &&
                 Objects.equals(url, that.url) &&
                 Objects.equals(httpVersion, that.httpVersion) &&
                 Objects.equals(cookies, that.cookies) &&
@@ -214,7 +214,7 @@ public class HarRequest {
 
     @Override
     public int hashCode() {
-        return Objects.hash(method, rawMethod, url, httpVersion, cookies, headers, queryString, postData, headersSize,
+        return Objects.hash(parsedMethod, method, url, httpVersion, cookies, headers, queryString, postData, headersSize,
                 bodySize, comment, additional);
     }
 }

--- a/src/main/java/de/sstoehr/harreader/model/HarResponse.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarResponse.java
@@ -22,8 +22,8 @@ public class HarResponse {
 
     protected static final Long DEFAULT_SIZE = -1L;
 
-    private HttpStatus status;
-    private int rawStatus = HttpStatus.UNKNOWN_HTTP_STATUS.getCode();
+    private HttpStatus parsedStatus;
+    private int status = HttpStatus.UNKNOWN_HTTP_STATUS.getCode();
     private String statusText;
     private String httpVersion;
     private List<HarCookie> cookies;
@@ -39,15 +39,15 @@ public class HarResponse {
      * @return Response status, 0 if not present or unknown.
      */
     public int getStatus() {
-        if (status == null) {
-            status = HttpStatus.UNKNOWN_HTTP_STATUS;
+        if (parsedStatus == null) {
+            parsedStatus = HttpStatus.UNKNOWN_HTTP_STATUS;
         }
-        return status.getCode();
+        return parsedStatus.getCode();
     }
 
     public void setStatus(int status) {
-        this.status = HttpStatus.byCode(status);
-        this.rawStatus = status;
+        this.parsedStatus = HttpStatus.byCode(status);
+        this.status = status;
     }
 
     /**
@@ -55,13 +55,13 @@ public class HarResponse {
      */
     @JsonProperty("status")
     public int getRawStatus() {
-        return rawStatus;
+        return status;
     }
 
     @JsonProperty("status")
     public void setRawStatus(int rawStatus) {
-        this.status = HttpStatus.byCode(rawStatus);
-        this.rawStatus = rawStatus;
+        this.parsedStatus = HttpStatus.byCode(rawStatus);
+        this.status = rawStatus;
     }
 
     /**
@@ -199,8 +199,8 @@ public class HarResponse {
         if (this == o) return true;
         if (!(o instanceof HarResponse)) return false;
         HarResponse that = (HarResponse) o;
-        return status == that.status &&
-                rawStatus == that.rawStatus &&
+        return parsedStatus == that.parsedStatus &&
+                status == that.status &&
                 Objects.equals(statusText, that.statusText) &&
                 Objects.equals(httpVersion, that.httpVersion) &&
                 Objects.equals(cookies, that.cookies) &&
@@ -215,7 +215,7 @@ public class HarResponse {
 
     @Override
     public int hashCode() {
-        return Objects.hash(status, rawStatus, statusText, httpVersion, cookies, headers, content, redirectURL, headersSize,
+        return Objects.hash(parsedStatus, status, statusText, httpVersion, cookies, headers, content, redirectURL, headersSize,
                 bodySize, comment, additional);
     }
 }


### PR DESCRIPTION
The exception is thrown starting from version `2.4.0` when attempting to use the model:
```
java.lang.IllegalArgumentException: Multiple fields representing property "method": de.sstoehr.harreader.model.HarRequest#method vs de.sstoehr.harreader.model.HarRequest#rawMethod
        at com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder.getField(POJOPropertyBuilder.java:643)
        at io.swagger.v3.core.jackson.ModelResolver.ignore(ModelResolver.java:1256)
        at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:631)
        at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
        at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:736)
        at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
        at io.swagger.v3.core.converter.ModelConverters.resolveAsResolvedSchema(ModelConverters.java:191)
        at io.swagger.v3.core.converter.ModelConverters.readAllAsResolvedSchema(ModelConverters.java:181)
        at io.swagger.v3.core.util.AnnotationsUtils.resolveSchemaFromType(AnnotationsUtils.java:898)
        at io.swagger.v3.core.util.AnnotationsUtils.getSchema(AnnotationsUtils.java:1744)
        at io.swagger.v3.core.util.AnnotationsUtils.getSchema(AnnotationsUtils.java:1723)
        at io.swagger.v3.core.util.AnnotationsUtils.getContent(AnnotationsUtils.java:1580)
        at io.swagger.v3.jaxrs2.OperationParser.getApiResponses(OperationParser.java:94)
        at io.swagger.v3.jaxrs2.Reader.setOperationObjectFromApiOperationAnnotation(Reader.java:1427)
        at io.swagger.v3.jaxrs2.Reader.parseMethod(Reader.java:1105)
        at io.swagger.v3.jaxrs2.Reader.parseMethod(Reader.java:956)
```
I haven't investigated it deeply, but my guess it happens because of mixup in fields and getters names. The fix has been tested locally, the error is not reproduced.
