### PR TITLE
Keep `browser` optional in `log` object

### DIFF
--- a/src/main/java/de/sstoehr/harreader/model/HarLog.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarLog.java
@@ -59,12 +59,9 @@ public class HarLog {
     }
 
     /**
-     * @return Information about the browser used.
+     * @return Information about the browser used, may be null.
      */
     public HarCreatorBrowser getBrowser() {
-        if (browser == null) {
-            browser = new HarCreatorBrowser();
-        }
         return browser;
     }
 

--- a/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
@@ -4,6 +4,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +64,7 @@ class HarLogTest extends AbstractMapperTest<HarLog> {
     void testBrowserNull() {
         HarLog log = new HarLog();
         log.setBrowser(null);
-        assertNotNull(log.getBrowser());
+        assertNull(log.getBrowser());
     }
 
     @Override


### PR DESCRIPTION
According to the specification (http://www.softwareishard.com/blog/har-12-spec/#log) `browser` field is optional in `log`:

"browser [object, optional] - Name and version info of used browser."

 thus it is not required to create a default value in the getter.