### PR TITLE
Use `IOException` as parent for `HarReaderException` and `HarWriterException`

### DIFF
--- a/src/main/java/de/sstoehr/harreader/HarReaderException.java
+++ b/src/main/java/de/sstoehr/harreader/HarReaderException.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader;
 
-public class HarReaderException extends Exception {
+import java.io.IOException;
+
+public class HarReaderException extends IOException {
 
     public HarReaderException(Throwable cause) {
         super(cause);

--- a/src/main/java/de/sstoehr/harreader/HarWriterException.java
+++ b/src/main/java/de/sstoehr/harreader/HarWriterException.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader;
 
-public class HarWriterException extends Exception {
+import java.io.IOException;
+
+public class HarWriterException extends IOException {
 
     public HarWriterException(Throwable cause) {
         super(cause);


### PR DESCRIPTION
As `HarReaderException` and `HarWriterException` represent I/O errors, it makes sense to use `IOException` as a parent for them to simplify subsequent exception handling.