### PR TITLE
Added builders to model objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.36</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.11.3</version>
@@ -69,6 +76,13 @@
                 <version>3.13.0</version>
                 <configuration>
                     <release>17</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.36</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/de/sstoehr/harreader/model/Har.java
+++ b/src/main/java/de/sstoehr/harreader/model/Har.java
@@ -2,16 +2,18 @@ package de.sstoehr.harreader.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
  * Main HTTP Archive Class.
- * @see <a href="http://www.softwareishard.com/blog/har-12-spec/">speicification</a>
+ * @see <a href="http://www.softwareishard.com/blog/har-12-spec/">specification</a>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record Har(@Nonnull HarLog log) {
 
     public Har(@Nullable HarLog log) {

--- a/src/main/java/de/sstoehr/harreader/model/HarCache.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCache.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -18,6 +19,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarCache(
         @Nullable HarCacheInfo beforeRequest,
         @Nullable HarCacheInfo afterRequest,
@@ -55,6 +57,7 @@ public record HarCache(
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @Builder(toBuilder = true)
     public record HarCacheInfo(@Nullable @JsonFormat(shape = JsonFormat.Shape.STRING) ZonedDateTime expires,
                                       @Nullable @JsonFormat(shape = JsonFormat.Shape.STRING) ZonedDateTime lastAccess,
                                       @Nullable String eTag,

--- a/src/main/java/de/sstoehr/harreader/model/HarContent.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarContent.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,6 +17,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarContent(
         @Nullable Long size,
         @Nullable Long compression,

--- a/src/main/java/de/sstoehr/harreader/model/HarCookie.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCookie.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -18,6 +19,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarCookie(
         @Nullable String name,
         @Nullable String value,

--- a/src/main/java/de/sstoehr/harreader/model/HarCreatorBrowser.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarCreatorBrowser.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,6 +17,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarCreatorBrowser(
         @Nullable String name,
         @Nullable String version,

--- a/src/main/java/de/sstoehr/harreader/model/HarEntry.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarEntry.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -18,6 +19,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarEntry(
         @Nullable String pageref,
         @Nullable @JsonFormat(shape = JsonFormat.Shape.STRING) ZonedDateTime startedDateTime,

--- a/src/main/java/de/sstoehr/harreader/model/HarHeader.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarHeader.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,6 +17,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarHeader(
         @Nullable String name,
         @Nullable String value,

--- a/src/main/java/de/sstoehr/harreader/model/HarLog.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarLog.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Singular;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -18,12 +20,13 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarLog(
         @Nonnull String version,
         @Nonnull HarCreatorBrowser creator,
         @Nullable HarCreatorBrowser browser,
-        @Nonnull List<HarPage> pages,
-        @Nonnull List<HarEntry> entries,
+        @Nonnull @Singular("page") List<HarPage> pages,
+        @Nonnull @Singular("entry") List<HarEntry> entries,
         @Nullable String comment,
         @Nonnull Map<String, Object> additional) {
 

--- a/src/main/java/de/sstoehr/harreader/model/HarPage.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPage.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -18,6 +19,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarPage(
         @Nullable @JsonFormat(shape = JsonFormat.Shape.STRING) ZonedDateTime startedDateTime,
         @Nullable String id,

--- a/src/main/java/de/sstoehr/harreader/model/HarPageTiming.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPageTiming.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,6 +17,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarPageTiming(
         @Nonnull Integer onContentLoad,
         @Nonnull Integer onLoad,

--- a/src/main/java/de/sstoehr/harreader/model/HarPostData.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPostData.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -18,6 +19,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarPostData(
         @Nullable String mimeType,
         @Nonnull List<HarPostDataParam> params,

--- a/src/main/java/de/sstoehr/harreader/model/HarPostDataParam.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarPostDataParam.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,12 +17,13 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarPostDataParam(@Nullable String name,
-        @Nullable String value,
-        @Nullable String fileName,
-        @Nullable String contentType,
-        @Nullable String comment,
-        @Nonnull Map<String, Object> additional) {
+                               @Nullable String value,
+                               @Nullable String fileName,
+                               @Nullable String contentType,
+                               @Nullable String comment,
+                               @Nonnull Map<String, Object> additional) {
 
     public HarPostDataParam() {
         this(null, null, null, null, null, new HashMap<>());

--- a/src/main/java/de/sstoehr/harreader/model/HarQueryParam.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarQueryParam.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -16,6 +17,7 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarQueryParam(
         @Nullable String name,
         @Nullable String value,

--- a/src/main/java/de/sstoehr/harreader/model/HarRequest.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarRequest.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
 import com.fasterxml.jackson.annotation.*;
+import lombok.Builder;
+import lombok.Singular;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,13 +17,14 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarRequest(
         @Nullable String method,
         @Nullable String url,
         @Nullable String httpVersion,
-        @Nonnull List<HarCookie> cookies,
-        @Nonnull List<HarHeader> headers,
-        @Nonnull List<HarQueryParam> queryString,
+        @Nonnull @Singular("cookie") List<HarCookie> cookies,
+        @Nonnull @Singular("header") List<HarHeader> headers,
+        @Nonnull @Singular("queryString") List<HarQueryParam> queryString,
         @Nonnull HarPostData postData,
         @Nonnull Long headersSize,
         @Nonnull Long bodySize,

--- a/src/main/java/de/sstoehr/harreader/model/HarResponse.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarResponse.java
@@ -1,6 +1,8 @@
 package de.sstoehr.harreader.model;
 
 import com.fasterxml.jackson.annotation.*;
+import lombok.Builder;
+import lombok.Singular;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,12 +17,13 @@ import java.util.Map;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarResponse(
         int status,
         @Nullable String statusText,
         @Nullable String httpVersion,
-        @Nonnull List<HarCookie> cookies,
-        @Nonnull List<HarHeader> headers,
+        @Nonnull @Singular("cookie") List<HarCookie> cookies,
+        @Nonnull @Singular("header") List<HarHeader> headers,
         @Nonnull HarContent content,
         @Nullable String redirectURL,
         @Nonnull Long headersSize,

--- a/src/main/java/de/sstoehr/harreader/model/HarTiming.java
+++ b/src/main/java/de/sstoehr/harreader/model/HarTiming.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -14,6 +15,7 @@ import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Builder(toBuilder = true)
 public record HarTiming(
         @Nonnull Integer blocked,
         @Nonnull Integer dns,

--- a/src/test/java/de/sstoehr/harreader/model/HarCacheTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCacheTest.java
@@ -46,6 +46,22 @@ class HarCacheTest extends AbstractMapperTest<HarCache> {
     }
 
     @Test
+    void testBuilder() {
+        HarCache cache = HarCache.builder().build();
+        testNullability(cache);
+
+        cache = HarCache.builder()
+                .beforeRequest(HarCache.HarCacheInfo.builder().build())
+                .afterRequest(HarCache.HarCacheInfo.builder().build())
+                .comment("comment")
+                .build();
+
+        assertNotNull(cache.beforeRequest());
+        assertNotNull(cache.afterRequest());
+        assertEquals("comment", cache.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarCache.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarContentTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarContentTest.java
@@ -36,6 +36,28 @@ class HarContentTest extends AbstractMapperTest<HarContent> {
     }
 
     @Test
+    void testBuilder() {
+        HarContent content = HarContent.builder().build();
+        testNullability(content);
+
+        content = HarContent.builder()
+                .size(123L)
+                .compression(45L)
+                .mimeType("mime/type")
+                .text("my content")
+                .encoding("base64")
+                .comment("my comment")
+                .build();
+
+        assertEquals(123L, (long) content.size());
+        assertEquals(45L, (long) content.compression());
+        assertEquals("mime/type", content.mimeType());
+        assertEquals("my content", content.text());
+        assertEquals("base64", content.encoding());
+        assertEquals("my comment", content.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarContent.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarCookieTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCookieTest.java
@@ -44,6 +44,32 @@ class HarCookieTest extends AbstractMapperTest<HarCookie> {
     }
 
     @Test
+    void testBuilder() {
+        HarCookie cookie = HarCookie.builder().build();
+        testNullability(cookie);
+
+        cookie = HarCookie.builder()
+                .name("aName")
+                .value("aValue")
+                .path("/")
+                .domain("sstoehr.de")
+                .expires(EXPECTED_EXPIRES)
+                .httpOnly(true)
+                .secure(false)
+                .comment("my comment")
+                .build();
+
+        assertEquals("aName", cookie.name());
+        assertEquals("aValue", cookie.value());
+        assertEquals("/", cookie.path());
+        assertEquals("sstoehr.de", cookie.domain());
+        assertEquals(EXPECTED_EXPIRES, cookie.expires());
+        assertEquals(true, cookie.httpOnly());
+        assertEquals(false, cookie.secure());
+        assertEquals("my comment", cookie.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarCookie.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarCreatorBrowserTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarCreatorBrowserTest.java
@@ -32,6 +32,22 @@ class HarCreatorBrowserTest extends AbstractMapperTest<HarCreatorBrowser> {
     }
 
     @Test
+    void testBuilder() {
+        HarCreatorBrowser creatorBrowser = HarCreatorBrowser.builder().build();
+        testNullability(creatorBrowser);
+
+        creatorBrowser = HarCreatorBrowser.builder()
+                .name("aName")
+                .version("aVersion")
+                .comment("my comment")
+                .build();
+
+        assertEquals("aName", creatorBrowser.name());
+        assertEquals("aVersion", creatorBrowser.version());
+        assertEquals("my comment", creatorBrowser.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarCreatorBrowser.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarEntryTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarEntryTest.java
@@ -69,6 +69,36 @@ public class HarEntryTest extends AbstractMapperTest<HarEntry> {
     }
 
     @Test
+    void testBuilder() {
+        HarEntry entry = HarEntry.builder().build();
+        testNullability(entry);
+
+        entry = HarEntry.builder()
+                .pageref("aPageref")
+                .startedDateTime(EXPECTED_STARTED)
+                .time(12345)
+                .request(HarRequest.builder().build())
+                .response(HarResponse.builder().build())
+                .cache(HarCache.builder().build())
+                .timings(HarTiming.builder().build())
+                .serverIPAddress("server.ip")
+                .connection("connection")
+                .comment("comment")
+                .build();
+
+        assertEquals("aPageref", entry.pageref());
+        assertEquals(EXPECTED_STARTED, entry.startedDateTime());
+        assertEquals(12345, (int) entry.time());
+        assertNotNull(entry.request());
+        assertNotNull(entry.response());
+        assertNotNull(entry.cache());
+        assertNotNull(entry.timings());
+        assertEquals("server.ip", entry.serverIPAddress());
+        assertEquals("connection", entry.connection());
+        assertEquals("comment", entry.comment());
+    }
+
+    @Test
     public void equalsContract() {
         EqualsVerifier.simple().forClass(HarEntry.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarHeaderTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarHeaderTest.java
@@ -32,6 +32,22 @@ class HarHeaderTest extends AbstractMapperTest<HarHeader> {
     }
 
     @Test
+    void testBuilder() {
+        HarHeader header = HarHeader.builder().build();
+        testNullability(header);
+
+        header = HarHeader.builder()
+                .name("aName")
+                .value("aValue")
+                .comment("my comment")
+                .build();
+
+        assertEquals("aName", header.name());
+        assertEquals("aValue", header.value());
+        assertEquals("my comment", header.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarHeader.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarLogTest.java
@@ -90,6 +90,24 @@ class HarLogTest extends AbstractMapperTest<HarLog> {
     }
 
     @Test
+    void testBuilder() {
+        HarLog log = HarLog.builder().build();
+        testNullability(log);
+
+        log = HarLog.builder()
+                .version("1.2")
+                .creator(HarCreatorBrowser.builder().build())
+                .browser(HarCreatorBrowser.builder().build())
+                .comment("My comment")
+                .build();
+
+        assertEquals("1.2", log.version());
+        assertNotNull(log.creator());
+        assertNotNull(log.browser());
+        assertEquals("My comment", log.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarLog.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarPageTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPageTest.java
@@ -45,6 +45,26 @@ class HarPageTest extends AbstractMapperTest<HarPage> {
     }
 
     @Test
+    void testBuilder() {
+        HarPage page = HarPage.builder().build();
+        testNullability(page);
+
+        page = HarPage.builder()
+                .startedDateTime(EXPECTED_STARTED)
+                .id("anId")
+                .title("aTitle")
+                .pageTimings(HarPageTiming.builder().build())
+                .comment("my comment")
+                .build();
+
+        assertEquals(EXPECTED_STARTED, page.startedDateTime());
+        assertEquals("anId", page.id());
+        assertEquals("aTitle", page.title());
+        assertNotNull(page.pageTimings());
+        assertEquals("my comment", page.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarPage.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarPageTimingTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPageTimingTest.java
@@ -51,6 +51,22 @@ class HarPageTimingTest extends AbstractMapperTest<HarPageTiming> {
     }
 
     @Test
+    void testBuilder() {
+        HarPageTiming pageTiming = HarPageTiming.builder().build();
+        testNullability(pageTiming);
+
+        pageTiming = HarPageTiming.builder()
+                .onContentLoad(1234)
+                .onLoad(5678)
+                .comment("My comment")
+                .build();
+
+        assertEquals(1234, (int) pageTiming.onContentLoad());
+        assertEquals(5678, (int) pageTiming.onLoad());
+        assertEquals("My comment", pageTiming.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarPageTiming.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarPostDataParamTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPostDataParamTest.java
@@ -33,6 +33,26 @@ class HarPostDataParamTest extends AbstractMapperTest<HarPostDataParam> {
     }
 
     @Test
+    void testBuilder() {
+        HarPostDataParam postDataParam = HarPostDataParam.builder().build();
+        testNullability(postDataParam);
+
+        postDataParam = HarPostDataParam.builder()
+                .name("aName")
+                .value("aValue")
+                .fileName("aFilename")
+                .contentType("aContentType")
+                .comment("My comment")
+                .build();
+
+        assertEquals("aName", postDataParam.name());
+        assertEquals("aValue", postDataParam.value());
+        assertEquals("aFilename", postDataParam.fileName());
+        assertEquals("aContentType", postDataParam.contentType());
+        assertEquals("My comment", postDataParam.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarPostDataParam.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarPostDataTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarPostDataTest.java
@@ -42,6 +42,24 @@ public class HarPostDataTest extends AbstractMapperTest<HarPostData> {
     }
 
     @Test
+    void testBuilder() {
+        HarPostData postData = HarPostData.builder().build();
+        testNullability(postData);
+
+        postData = HarPostData.builder()
+                .mimeType("aMimeType")
+                .params(EXPECTED_LIST)
+                .text("aText")
+                .comment("My comment")
+                .build();
+
+        assertEquals("aMimeType", postData.mimeType());
+        assertEquals(EXPECTED_LIST, postData.params());
+        assertEquals("aText", postData.text());
+        assertEquals("My comment", postData.comment());
+    }
+
+    @Test
     public void equalsContract() {
         EqualsVerifier.simple().forClass(HarPostData.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarQueryParamTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarQueryParamTest.java
@@ -28,6 +28,22 @@ class HarQueryParamTest extends AbstractMapperTest<HarQueryParam> {
     }
 
     @Test
+    void testBuilder() {
+        HarQueryParam queryParam = HarQueryParam.builder().build();
+        testNullability(queryParam);
+
+        queryParam = HarQueryParam.builder()
+                .name("aName")
+                .value("aValue")
+                .comment("My comment")
+                .build();
+
+        assertEquals("aName", queryParam.name());
+        assertEquals("aValue", queryParam.value());
+        assertEquals("My comment", queryParam.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarQueryParam.class).verify();
     }

--- a/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarRequestTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class HarRequestTest extends AbstractMapperTest<HarRequest> {
@@ -95,6 +98,37 @@ class HarRequestTest extends AbstractMapperTest<HarRequest> {
     @Test
     void testNullability() {
         testNullability(new HarRequest());
+    }
+
+    @Test
+    void testBuilder() {
+        HarRequest request = HarRequest.builder().build();
+        testNullability(request);
+
+        request = HarRequest.builder()
+                .method("GET")
+                .url("http://www.sebastianstoehr.de/")
+                .httpVersion("HTTP/1.1")
+                .cookies(List.of(HarCookie.builder().build()))
+                .headers(List.of(HarHeader.builder().build()))
+                .queryString(Collections.emptyList())
+                .postData(HarPostData.builder().build())
+                .headersSize(676L)
+                .bodySize(-1L)
+                .comment("my comment")
+                .build();
+
+        assertEquals(HttpMethod.GET, request.httpMethod());
+        assertEquals("GET", request.method());
+        assertEquals("http://www.sebastianstoehr.de/", request.url());
+        assertEquals("HTTP/1.1", request.httpVersion());
+        assertNotNull(request.cookies());
+        assertNotNull(request.headers());
+        assertNotNull(request.queryString());
+        assertNotNull(request.postData());
+        assertEquals(676L, (long) request.headersSize());
+        assertEquals(-1L, (long) request.bodySize());
+        assertEquals("my comment", request.comment());
     }
 
     @Test

--- a/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarResponseTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 class HarResponseTest extends AbstractMapperTest<HarResponse> {
 
     @Override
@@ -86,6 +88,36 @@ class HarResponseTest extends AbstractMapperTest<HarResponse> {
     @Test
     void testNullability() {
         testNullability(new HarResponse());
+    }
+
+    @Test
+    void testBuilder() {
+        HarResponse response = HarResponse.builder().build();
+        testNullability(response);
+
+        response = HarResponse.builder()
+                .status(200)
+                .statusText("OK")
+                .httpVersion("HTTP/1.1")
+                .cookies(List.of(HarCookie.builder().build()))
+                .headers(List.of(HarHeader.builder().build()))
+                .content(HarContent.builder().build())
+                .redirectURL("redirectUrl")
+                .headersSize(318L)
+                .bodySize(16997L)
+                .comment("My comment")
+                .build();
+
+        assertEquals(200, response.status());
+        assertEquals("OK", response.statusText());
+        assertEquals("HTTP/1.1", response.httpVersion());
+        assertNotNull(response.cookies());
+        assertNotNull(response.headers());
+        assertNotNull(response.content());
+        assertEquals("redirectUrl", response.redirectURL());
+        assertEquals(318L, (long) response.headersSize());
+        assertEquals(16997L, (long) response.bodySize());
+        assertEquals("My comment", response.comment());
     }
 
     @Test

--- a/src/test/java/de/sstoehr/harreader/model/HarTimingTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/HarTimingTest.java
@@ -76,6 +76,32 @@ class HarTimingTest extends AbstractMapperTest<HarTiming> {
     }
 
     @Test
+    void testBuilder() {
+        HarTiming timing = HarTiming.builder().build();
+        testNullability(timing);
+
+        timing = HarTiming.builder()
+                .blocked(3804)
+                .dns(23)
+                .connect(5)
+                .send(9)
+                .waitTime(5209)
+                .receive(79)
+                .ssl(123)
+                .comment("my comment")
+                .build();
+
+        assertEquals(3804, (int) timing.blocked());
+        assertEquals(23, (int) timing.dns());
+        assertEquals(5, (int) timing.connect());
+        assertEquals(9, (int) timing.send());
+        assertEquals(5209, (int) timing.waitTime());
+        assertEquals(79, (int) timing.receive());
+        assertEquals(123, (int) timing.ssl());
+        assertEquals("my comment", timing.comment());
+    }
+
+    @Test
     void equalsContract() {
         EqualsVerifier.simple().forClass(HarTiming.class).verify();
     }


### PR DESCRIPTION
With the latest additional of `HarWriter` the importance to manually create the HAR model objects increased (previously the classes were mainly intended for read access).

This PR improves the abilities to create the model objects by offering a builder pattern:

```java
HarRequest request = HarRequest.builder()
        .method("GET")
        .url("http://www.sebastianstoehr.de/")
        .httpVersion("HTTP/1.1")
        .cookie(HarCookie.builder().build())
        .headers(List.of(HarHeader.builder().build()))
        .queryString(Collections.emptyList())
        .headersSize(676L)
        .build();
```

You can also create a pre-filled builder object:

```java
HarRequest updatedRequest = request.toBuilder().method("POST").build();
```
