### PR TITLE
upgrade Jackson from 2.20.0 to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,26 +13,26 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.20.0</jackson.version>
+        <jackson.version>3.0.0</jackson.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.20</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/de/sstoehr/harreader/AbstractHarIO.java
+++ b/src/main/java/de/sstoehr/harreader/AbstractHarIO.java
@@ -1,12 +1,11 @@
 package de.sstoehr.harreader;
 
-import java.io.IOException;
-import java.util.function.Function;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import de.sstoehr.harreader.jackson.DefaultMapperFactory;
 import de.sstoehr.harreader.jackson.MapperFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.function.Function;
 
 public abstract class AbstractHarIO {
     private final MapperFactory mapperFactory;
@@ -27,10 +26,10 @@ public abstract class AbstractHarIO {
     }
 
     protected static <T, E extends Exception> T wrap(ObjectMapper mapper, IOFunction<ObjectMapper, T> consumer,
-            Function<IOException, E> exceptionFactory) throws E {
+            Function<JacksonException, E> exceptionFactory) throws E {
         try {
             return consumer.apply(mapper);
-        } catch(IOException thrown) {
+        } catch(JacksonException thrown) {
             throw exceptionFactory.apply(thrown);
         }
     }
@@ -38,7 +37,7 @@ public abstract class AbstractHarIO {
     @FunctionalInterface
     protected interface IOFunction<T, R> {
 
-        R apply(T object) throws IOException;
+        R apply(T object) throws JacksonException;
 
     }
 

--- a/src/main/java/de/sstoehr/harreader/HarReader.java
+++ b/src/main/java/de/sstoehr/harreader/HarReader.java
@@ -1,12 +1,11 @@
 package de.sstoehr.harreader;
 
-import java.io.File;
-import java.io.InputStream;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import de.sstoehr.harreader.jackson.MapperFactory;
 import de.sstoehr.harreader.model.Har;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.File;
+import java.io.InputStream;
 
 public class HarReader extends AbstractHarIO {
 

--- a/src/main/java/de/sstoehr/harreader/HarWriter.java
+++ b/src/main/java/de/sstoehr/harreader/HarWriter.java
@@ -1,13 +1,12 @@
 package de.sstoehr.harreader;
 
+import de.sstoehr.harreader.jackson.MapperFactory;
+import de.sstoehr.harreader.model.Har;
+import tools.jackson.databind.ObjectMapper;
+
 import java.io.File;
 import java.io.OutputStream;
 import java.io.Writer;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import de.sstoehr.harreader.jackson.MapperFactory;
-import de.sstoehr.harreader.model.Har;
 
 public final class HarWriter extends AbstractHarIO {
 

--- a/src/main/java/de/sstoehr/harreader/jackson/DefaultMapperFactory.java
+++ b/src/main/java/de/sstoehr/harreader/jackson/DefaultMapperFactory.java
@@ -1,33 +1,35 @@
 package de.sstoehr.harreader.jackson;
 
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.util.Date;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.sstoehr.harreader.HarReaderMode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+
+import java.time.ZonedDateTime;
+
+import static tools.jackson.databind.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES;
+import static tools.jackson.databind.cfg.DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE;
 
 public class DefaultMapperFactory implements MapperFactory {
 
     public ObjectMapper instance(HarReaderMode mode) {
-        SimpleModule module = new SimpleModule();
         if (mode == HarReaderMode.LAX) {
-            module.addDeserializer(ZonedDateTime.class, new ExceptionIgnoringZonedDateTimeDeserializer());
-            module.addDeserializer(Integer.class, new ExceptionIgnoringIntegerDeserializer());
+            SimpleModule module = new SimpleModule()
+              .addDeserializer(ZonedDateTime.class, new ExceptionIgnoringZonedDateTimeDeserializer())
+              .addDeserializer(Integer.class, new ExceptionIgnoringIntegerDeserializer());
+            return builder().addModule(module).build();
         }
-        return instance().registerModule(module);
+        return instance();
     }
 
     public ObjectMapper instance() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
-
-        return mapper;
+      return builder().build();
     }
+
+  private JsonMapper.Builder builder() {
+    return JsonMapper.builder()
+      .configure(ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
+      .configure(FAIL_ON_NULL_FOR_PRIMITIVES, false);
+  }
 
 }

--- a/src/main/java/de/sstoehr/harreader/jackson/ExceptionIgnoringIntegerDeserializer.java
+++ b/src/main/java/de/sstoehr/harreader/jackson/ExceptionIgnoringIntegerDeserializer.java
@@ -1,21 +1,19 @@
 package de.sstoehr.harreader.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.std.NumberDeserializers;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.jdk.NumberDeserializers;
 
-import java.io.IOException;
-
-public class ExceptionIgnoringIntegerDeserializer extends JsonDeserializer<Integer> {
+public class ExceptionIgnoringIntegerDeserializer extends ValueDeserializer<Integer> {
     @Override
-    public Integer deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+    public Integer deserialize(JsonParser jp, DeserializationContext ctxt) {
         try {
             NumberDeserializers.IntegerDeserializer integerDeserializer = new NumberDeserializers.IntegerDeserializer(Integer.class, null);
             return integerDeserializer.deserialize(jp, ctxt);
-        } catch (IOException e) {
-            //ignore
+        } catch (JacksonException ignore) {
+            return null;
         }
-        return null;
     }
 }

--- a/src/main/java/de/sstoehr/harreader/jackson/ExceptionIgnoringZonedDateTimeDeserializer.java
+++ b/src/main/java/de/sstoehr/harreader/jackson/ExceptionIgnoringZonedDateTimeDeserializer.java
@@ -1,25 +1,24 @@
 package de.sstoehr.harreader.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ext.javatime.deser.InstantDeserializer;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-public class ExceptionIgnoringZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
+public class ExceptionIgnoringZonedDateTimeDeserializer extends ValueDeserializer<ZonedDateTime> {
 
     @Override
-    public ZonedDateTime deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+    public ZonedDateTime deserialize(JsonParser jp, DeserializationContext ctxt) {
         try {
             return InstantDeserializer.ZONED_DATE_TIME.deserialize(jp, ctxt);
-        } catch (IOException e) {
-            //ignore
+        } catch (JacksonException ignore) {
+            return ZonedDateTime.ofInstant(Instant.ofEpochSecond(0L), ZoneId.of("UTC"));
         }
-        return ZonedDateTime.ofInstant(Instant.ofEpochSecond(0L), ZoneId.of("UTC"));
     }
 
 }

--- a/src/main/java/de/sstoehr/harreader/jackson/MapperFactory.java
+++ b/src/main/java/de/sstoehr/harreader/jackson/MapperFactory.java
@@ -1,8 +1,7 @@
 package de.sstoehr.harreader.jackson;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import de.sstoehr.harreader.HarReaderMode;
+import tools.jackson.databind.ObjectMapper;
 
 public interface MapperFactory {
 

--- a/src/test/java/de/sstoehr/harreader/HarWriterTests.java
+++ b/src/test/java/de/sstoehr/harreader/HarWriterTests.java
@@ -1,19 +1,7 @@
 package de.sstoehr.harreader;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.time.ZonedDateTime;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.sstoehr.harreader.jackson.DefaultMapperFactory;
+import de.sstoehr.harreader.model.Har;
 import de.sstoehr.harreader.model.HarCreatorBrowser;
 import de.sstoehr.harreader.model.HarEntry;
 import de.sstoehr.harreader.model.HarLog;
@@ -21,13 +9,22 @@ import de.sstoehr.harreader.model.HarRequest;
 import de.sstoehr.harreader.model.HarResponse;
 import de.sstoehr.harreader.model.HttpMethod;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
-import de.sstoehr.harreader.model.Har;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.time.ZonedDateTime;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class HarWriterTests {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
+    private static final ObjectMapper MAPPER = JsonMapper.builder()
+            .configure(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false).build();
     private static final File HAR_FILE = new File("src/test/resources/sstoehr.har");
 
     @Test
@@ -45,7 +42,7 @@ class HarWriterTests {
 
         Har har = new HarReader().readFromFile(HAR_FILE);
         HarWriter writer = new HarWriter(new DefaultMapperFactory());
-        assertEquals(MAPPER.writeValueAsString(expected), new String(writer.writeAsBytes(har), StandardCharsets.UTF_8));
+        assertEquals(MAPPER.writeValueAsString(expected), new String(writer.writeAsBytes(har), UTF_8));
     }
 
     @Test
@@ -55,7 +52,7 @@ class HarWriterTests {
 
         HarWriter writer = new HarWriter();
         writer.writeTo(baos, expected);
-        assertEquals(MAPPER.writeValueAsString(expected), new String(baos.toByteArray(), StandardCharsets.UTF_8));
+        assertEquals(MAPPER.writeValueAsString(expected), baos.toString(UTF_8));
     }
 
     @Test

--- a/src/test/java/de/sstoehr/harreader/model/AbstractMapperTest.java
+++ b/src/test/java/de/sstoehr/harreader/model/AbstractMapperTest.java
@@ -1,19 +1,14 @@
 package de.sstoehr.harreader.model;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import de.sstoehr.harreader.jackson.DefaultMapperFactory;
 import org.junit.jupiter.api.Assertions;
+import tools.jackson.databind.ObjectMapper;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.lang.reflect.Field;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractMapperTest<T> {
 


### PR DESCRIPTION
it's a major release including:
1. Renamed Maven "groupId" from "com.fasterxml.jackson.*" to "tools.jackson.*"
2. Renamed java package from "com.fasterxml.jackson.*" to "tools.jackson.*"

See https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md